### PR TITLE
Use PropTypes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,7 +24,7 @@
     "linebreak-style": ["error", "unix"],
     "max-len": ["warn", { "code": 100 }],
     "quotes": ["error", "single"],
-    "react/prop-types": "off", // We should consider setting this to "warn"
+    "react/prop-types": "warn",
     "semi": ["error", "always"]
   }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,5 +26,10 @@
     "quotes": ["error", "single"],
     "react/prop-types": "warn",
     "semi": ["error", "always"]
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
+    }
   }
 }

--- a/App/App.js
+++ b/App/App.js
@@ -1,22 +1,22 @@
-import React from "react";
-import { Provider } from "react-redux";
+import React from 'react';
+import { Provider } from 'react-redux';
 import { registerRootComponent } from 'expo';
 
-import store from "store";
-import AppTheme from "theme/AppTheme";
-import RootNavigation from "navigation/RootNavigation";
+import store from 'store';
+import AppTheme from 'theme/AppTheme';
+import RootNavigation from 'navigation/RootNavigation';
 import RootContainer from './RootContainer';
 
 const App = () => {
-    return (
-        <Provider store={store}>
-            <AppTheme>
-              <RootContainer>
-                <RootNavigation />
-              </RootContainer>
-            </AppTheme>
-        </Provider>
-    );
+  return (
+    <Provider store={store}>
+      <AppTheme>
+        <RootContainer>
+          <RootNavigation />
+        </RootContainer>
+      </AppTheme>
+    </Provider>
+  );
 };
 
 export default registerRootComponent(App);

--- a/App/RootContainer.js
+++ b/App/RootContainer.js
@@ -13,6 +13,6 @@ export default function RootContainer({ children }) {
   const storeRehydrated = useSelector(selectors.storeRehydrated);
   usePersistStore();
 
-  if (!storeRehydrated) return null
+  if (!storeRehydrated) return null;
   return children;
 }

--- a/App/RootContainer.js
+++ b/App/RootContainer.js
@@ -3,7 +3,6 @@
 The purpose of this component is to place any app level logic that needs to happen
 
 */
-import React from 'react';
 import { useSelector } from 'react-redux';
 
 import { usePersistStore } from 'lib/hooks';

--- a/App/components/Bible/Chapter.js
+++ b/App/components/Bible/Chapter.js
@@ -1,7 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Verse from './Verse';
 
 export default function Chapter({ verses }) {
   return verses?.map((verse, i) => <Verse key={`${i} ${verse}`} number={i + 1} text={verse} />);
 }
+
+Chapter.propTypes = {
+  verses: PropTypes.array
+};

--- a/App/components/Bible/Chapter.js
+++ b/App/components/Bible/Chapter.js
@@ -8,5 +8,5 @@ export default function Chapter({ verses }) {
 }
 
 Chapter.propTypes = {
-  verses: PropTypes.array
+  verses: PropTypes.array.isRequired
 };

--- a/App/components/Bible/Chapter.js
+++ b/App/components/Bible/Chapter.js
@@ -8,5 +8,5 @@ export default function Chapter({ verses }) {
 }
 
 Chapter.propTypes = {
-  verses: PropTypes.array.isRequired
+  verses: PropTypes.arrayOf(PropTypes.string).isRequired
 };

--- a/App/components/Bible/Verse.js
+++ b/App/components/Bible/Verse.js
@@ -19,6 +19,6 @@ const Text = styled.Text(({ theme }) => ({
 }));
 
 Verse.propTypes = {
-  number: PropTypes.number,
-  text: PropTypes.string
+  number: PropTypes.number.isRequired,
+  text: PropTypes.string.isRequired
 };

--- a/App/components/Bible/Verse.js
+++ b/App/components/Bible/Verse.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/native';
 
 export default function Verse({ number, text }) {
@@ -16,3 +17,8 @@ const Text = styled.Text(({ theme }) => ({
   marginBottom: 13,
   color: theme.text.reading,
 }));
+
+Verse.propTypes = {
+  number: PropTypes.number,
+  text: PropTypes.string
+};

--- a/App/components/Drawer/BookList.js
+++ b/App/components/Drawer/BookList.js
@@ -14,6 +14,6 @@ export default function BookList({ books, onSelectBook }) {
 }
 
 BookList.propTypes = {
-  books: PropTypes.array.isRequired,
+  books: PropTypes.arrayOf(PropTypes.string).isRequired,
   onSelectBook: PropTypes.func.isRequired
 };

--- a/App/components/Drawer/BookList.js
+++ b/App/components/Drawer/BookList.js
@@ -6,7 +6,7 @@ import BookTitle from 'components/Drawer/BookTitle';
 export default function BookList({ books, onSelectBook }) {
   return books?.map((book, i) => (
     <BookTitle
-      key={book}
+      key={`${book}-${i}`}
       book={book}
       onPress={() => onSelectBook(i)}
     />
@@ -14,6 +14,6 @@ export default function BookList({ books, onSelectBook }) {
 }
 
 BookList.propTypes = {
-  books: PropTypes.array,
-  onSelectBook: PropTypes.func
+  books: PropTypes.array.isRequired,
+  onSelectBook: PropTypes.func.isRequired
 };

--- a/App/components/Drawer/BookList.js
+++ b/App/components/Drawer/BookList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import BookTitle from 'components/Drawer/BookTitle';
 
@@ -11,3 +12,8 @@ export default function BookList({ books, onSelectBook }) {
     />
   ));
 }
+
+BookList.propTypes = {
+  books: PropTypes.array,
+  onSelectBook: PropTypes.func
+};

--- a/App/components/Drawer/BookList.js
+++ b/App/components/Drawer/BookList.js
@@ -1,14 +1,13 @@
-import React from "react";
+import React from 'react';
 
-import BookTitle from "components/Drawer/BookTitle";
+import BookTitle from 'components/Drawer/BookTitle';
 
 export default function BookList({ books, onSelectBook }) {
-	
-	return books?.map((book, i) => (
-		<BookTitle
-			key={book}
-			book={book}
-			onPress={() => onSelectBook(i)}
-		/>
-	));
+  return books?.map((book, i) => (
+    <BookTitle
+      key={book}
+      book={book}
+      onPress={() => onSelectBook(i)}
+    />
+  ));
 }

--- a/App/components/Drawer/BookTitle.js
+++ b/App/components/Drawer/BookTitle.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import { useTheme } from 'emotion-theming';
+import PropTypes from 'prop-types';
 import styled from '@emotion/native';
 import { AntDesign as Icon } from '@expo/vector-icons';
 
 export default function BookList({ book, onPress, isSelected = false }) {
   const { text } = useTheme();
-	
+
   return (
     <BookTitleContainer onPress={onPress}>
       <BookTitle>{book}</BookTitle>
@@ -19,7 +20,13 @@ export default function BookList({ book, onPress, isSelected = false }) {
   );
 }
 
-const BookTitleContainer = styled.TouchableOpacity(({ theme }) => ({
+BookList.propTypes = {
+  book: PropTypes.element,
+  onPress: PropTypes.func,
+  isSelected: PropTypes.bool
+};
+
+const BookTitleContainer = styled.TouchableOpacity(() => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'space-between',

--- a/App/components/Drawer/BookTitle.js
+++ b/App/components/Drawer/BookTitle.js
@@ -1,34 +1,34 @@
-import React from "react";
-import { useTheme } from "emotion-theming";
-import styled from "@emotion/native";
-import { AntDesign as Icon } from "@expo/vector-icons";
+import React from 'react';
+import { useTheme } from 'emotion-theming';
+import styled from '@emotion/native';
+import { AntDesign as Icon } from '@expo/vector-icons';
 
 export default function BookList({ book, onPress, isSelected = false }) {
-	const { text } = useTheme();
+  const { text } = useTheme();
 	
-	return (
-		<BookTitleContainer onPress={onPress}>
-			<BookTitle>{book}</BookTitle>
-			<Icon
-					name={isSelected ? "up" : "down"}
-					size={13}
-					style={{ marginTop: 5 }}
-					color={text.reading}
-			/>
-		</BookTitleContainer>
-	);
+  return (
+    <BookTitleContainer onPress={onPress}>
+      <BookTitle>{book}</BookTitle>
+      <Icon
+        name={isSelected ? 'up' : 'down'}
+        size={13}
+        style={{ marginTop: 5 }}
+        color={text.reading}
+      />
+    </BookTitleContainer>
+  );
 }
 
 const BookTitleContainer = styled.TouchableOpacity(({ theme }) => ({
-	display: "flex",
-	flexDirection: "row",
-	justifyContent: "space-between",
-	marginHorizontal: 7,
-	marginVertical: 5,
-	width: "93%",
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  marginHorizontal: 7,
+  marginVertical: 5,
+  width: '93%',
 }));
 
 const BookTitle = styled.Text(({ theme }) => ({
-	fontSize: 21,
-	color: theme.text.card,
+  fontSize: 21,
+  color: theme.text.card,
 }));

--- a/App/components/Drawer/BookTitle.js
+++ b/App/components/Drawer/BookTitle.js
@@ -21,8 +21,8 @@ export default function BookList({ book, onPress, isSelected = false }) {
 }
 
 BookList.propTypes = {
-  book: PropTypes.string,
-  onPress: PropTypes.func,
+  book: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired,
   isSelected: PropTypes.bool
 };
 

--- a/App/components/Drawer/BookTitle.js
+++ b/App/components/Drawer/BookTitle.js
@@ -21,7 +21,7 @@ export default function BookList({ book, onPress, isSelected = false }) {
 }
 
 BookList.propTypes = {
-  book: PropTypes.element,
+  book: PropTypes.string,
   onPress: PropTypes.func,
   isSelected: PropTypes.bool
 };

--- a/App/components/Drawer/ChapterList.js
+++ b/App/components/Drawer/ChapterList.js
@@ -14,8 +14,8 @@ export default function ChapterList({ chapters, onSelectChapter }) {
 }
 
 ChapterList.propTypes = {
-  chapters: PropTypes.array,
-  onSelectChapter: PropTypes.func
+  chapters: PropTypes.array.isRequired,
+  onSelectChapter: PropTypes.func.isRequired
 };
 
 const ChapterBox = styled.TouchableOpacity(({ theme }) => ({

--- a/App/components/Drawer/ChapterList.js
+++ b/App/components/Drawer/ChapterList.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/native';
 
 export default function ChapterList({ chapters, onSelectChapter }) {
@@ -11,6 +12,11 @@ export default function ChapterList({ chapters, onSelectChapter }) {
     </ChapterBox>
   ));
 }
+
+ChapterList.propTypes = {
+  chapters: PropTypes.array,
+  onSelectChapter: PropTypes.func
+};
 
 const ChapterBox = styled.TouchableOpacity(({ theme }) => ({
   display: 'flex',

--- a/App/components/Drawer/ChapterList.js
+++ b/App/components/Drawer/ChapterList.js
@@ -14,7 +14,7 @@ export default function ChapterList({ chapters, onSelectChapter }) {
 }
 
 ChapterList.propTypes = {
-  chapters: PropTypes.array.isRequired,
+  chapters: PropTypes.number.isRequired,
   onSelectChapter: PropTypes.func.isRequired
 };
 

--- a/App/components/Drawer/ChapterList.js
+++ b/App/components/Drawer/ChapterList.js
@@ -1,29 +1,29 @@
-import React from 'react'
-import styled from "@emotion/native";
+import React from 'react';
+import styled from '@emotion/native';
 
 export default function ChapterList({ chapters, onSelectChapter }) {
-	return [...Array(chapters)]?.map((x, i) => (
-		<ChapterBox
-			key={i}
-			onPress={() => onSelectChapter(i)}
-		>
-			<ChapterText>{i + 1}</ChapterText>
-		</ChapterBox>
-	));
+  return [...Array(chapters)]?.map((x, i) => (
+    <ChapterBox
+      key={i}
+      onPress={() => onSelectChapter(i)}
+    >
+      <ChapterText>{i + 1}</ChapterText>
+    </ChapterBox>
+  ));
 }
 
 const ChapterBox = styled.TouchableOpacity(({ theme }) => ({
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    marginHorizontal: 5,
-    marginVertical: 5,
-    width: 52,
-    height: 52,
-    backgroundColor: theme.background.card,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  marginHorizontal: 5,
+  marginVertical: 5,
+  width: 52,
+  height: 52,
+  backgroundColor: theme.background.card,
 }));
 
 const ChapterText = styled.Text(({ theme }) => ({
-    fontSize: 16,
-    color: theme.text.card,
+  fontSize: 16,
+  color: theme.text.card,
 }));

--- a/App/components/Drawer/DrawerHeader.js
+++ b/App/components/Drawer/DrawerHeader.js
@@ -1,53 +1,53 @@
-import React from "react"
-import styled from "@emotion/native";
+import React from 'react';
+import styled from '@emotion/native';
 
 export default function DrawerHeader({ testament, onPress }) {
-	return (
-		<Header>
-			<TitleContainer
-					selected={testament === "old"}
-					onPress={() => onPress("old")}
-			>
-					<Title selected={testament === "old"}>
+  return (
+    <Header>
+      <TitleContainer
+        selected={testament === 'old'}
+        onPress={() => onPress('old')}
+      >
+        <Title selected={testament === 'old'}>
 							Old T.
-					</Title>
-			</TitleContainer>
-			<TitleContainer
-					selected={testament === "new"}
-					onPress={() => onPress("new")}
-			>
-					<Title selected={testament === "new"}>
+        </Title>
+      </TitleContainer>
+      <TitleContainer
+        selected={testament === 'new'}
+        onPress={() => onPress('new')}
+      >
+        <Title selected={testament === 'new'}>
 							New T.
-					</Title>
-			</TitleContainer>
-		</Header>
-	);
+        </Title>
+      </TitleContainer>
+    </Header>
+  );
 }
 
 const Header = styled.View(({ theme }) => ({
-	display: "flex",
-	flexDirection: "row",
-	justifyContent: "space-between",
-	marginBottom: 3,
-	borderBottomWidth: 1,
-	borderBottomColor: theme.border.color,
-	paddingBottom: 10,
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'space-between',
+  marginBottom: 3,
+  borderBottomWidth: 1,
+  borderBottomColor: theme.border.color,
+  paddingBottom: 10,
 }));
 
 const TitleContainer = styled.TouchableOpacity(
-	({ theme, selected }) => {
-			if (!selected)
-					return {
-							borderBottomWidth: 1,
-							borderBottomColor: theme.border.color,
-					};
-	},
-	{
-			marginHorizontal: 7,
-	}
+  ({ theme, selected }) => {
+    if (!selected)
+      return {
+        borderBottomWidth: 1,
+        borderBottomColor: theme.border.color,
+      };
+  },
+  {
+    marginHorizontal: 7,
+  }
 );
 
 const Title = styled.Text(({ theme, selected }) => ({
-	color: selected ? theme.text.card : theme.text.secondary,
-	fontSize: 22,
+  color: selected ? theme.text.card : theme.text.secondary,
+  fontSize: 22,
 }));

--- a/App/components/Drawer/DrawerHeader.js
+++ b/App/components/Drawer/DrawerHeader.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/native';
 
 export default function DrawerHeader({ testament, onPress }) {
@@ -9,7 +10,7 @@ export default function DrawerHeader({ testament, onPress }) {
         onPress={() => onPress('old')}
       >
         <Title selected={testament === 'old'}>
-							Old T.
+          Old T.
         </Title>
       </TitleContainer>
       <TitleContainer
@@ -17,12 +18,17 @@ export default function DrawerHeader({ testament, onPress }) {
         onPress={() => onPress('new')}
       >
         <Title selected={testament === 'new'}>
-							New T.
+          New T.
         </Title>
       </TitleContainer>
     </Header>
   );
 }
+
+DrawerHeader.propTypes = {
+  testament: PropTypes.string,
+  onPress: PropTypes.func
+};
 
 const Header = styled.View(({ theme }) => ({
   display: 'flex',

--- a/App/components/Drawer/DrawerHeader.js
+++ b/App/components/Drawer/DrawerHeader.js
@@ -26,8 +26,8 @@ export default function DrawerHeader({ testament, onPress }) {
 }
 
 DrawerHeader.propTypes = {
-  testament: PropTypes.string,
-  onPress: PropTypes.func
+  testament: PropTypes.string.isRequired,
+  onPress: PropTypes.func.isRequired
 };
 
 const Header = styled.View(({ theme }) => ({

--- a/App/components/Settings/SettingsOption.js
+++ b/App/components/Settings/SettingsOption.js
@@ -24,9 +24,9 @@ export default function SettingsOption({ label, selected, onPress }) {
 }
 
 SettingsOption.propTypes = {
-  label: PropTypes.string,
-  selected: PropTypes.bool,
-  onPress: PropTypes.func
+  label: PropTypes.string.isRequired,
+  selected: PropTypes.bool.isRequired,
+  onPress: PropTypes.func.isRequired
 };
 
 const ButtonContainer = styled.View(() => ({

--- a/App/components/Settings/SettingsOption.js
+++ b/App/components/Settings/SettingsOption.js
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Ionicons as Icon } from '@expo/vector-icons';
 import { useTheme } from 'emotion-theming';
 import styled from '@emotion/native';
 
-export default function SettingsOption({ label, selected, onPress}) {
+export default function SettingsOption({ label, selected, onPress }) {
   const { text } = useTheme();
 
   return (
@@ -22,12 +23,18 @@ export default function SettingsOption({ label, selected, onPress}) {
   );
 }
 
-const ButtonContainer = styled.View(({ theme }) => ({
+SettingsOption.propTypes = {
+  label: PropTypes.string,
+  selected: PropTypes.bool,
+  onPress: PropTypes.func
+};
+
+const ButtonContainer = styled.View(() => ({
   display: 'flex',
   flexDirection: 'row',
 }));
 
-const Button = styled.TouchableOpacity(({ theme }) => ({
+const Button = styled.TouchableOpacity(() => ({
   marginRight: 20,
 }));
 

--- a/App/components/Settings/SettingsOption.js
+++ b/App/components/Settings/SettingsOption.js
@@ -1,39 +1,39 @@
 import React from 'react';
-import { Ionicons as Icon } from "@expo/vector-icons";
-import { useTheme } from "emotion-theming";
-import styled from "@emotion/native";
+import { Ionicons as Icon } from '@expo/vector-icons';
+import { useTheme } from 'emotion-theming';
+import styled from '@emotion/native';
 
 export default function SettingsOption({ label, selected, onPress}) {
-	const { text } = useTheme();
+  const { text } = useTheme();
 
-	return (
-		<ButtonContainer>
-			<Button onPress={onPress}>
-					<Option>{label}</Option>
-			</Button>
-			{selected && (
-				<Icon
-					name="md-checkmark-circle"
-					size={20}
-					color={text.reading}
-				/>
-			)}
-		</ButtonContainer>
-	);
+  return (
+    <ButtonContainer>
+      <Button onPress={onPress}>
+        <Option>{label}</Option>
+      </Button>
+      {selected && (
+        <Icon
+          name="md-checkmark-circle"
+          size={20}
+          color={text.reading}
+        />
+      )}
+    </ButtonContainer>
+  );
 }
 
 const ButtonContainer = styled.View(({ theme }) => ({
-	display: "flex",
-	flexDirection: "row",
+  display: 'flex',
+  flexDirection: 'row',
 }));
 
 const Button = styled.TouchableOpacity(({ theme }) => ({
-	marginRight: 20,
+  marginRight: 20,
 }));
 
 const Option = styled.Text(({ theme }) => ({
-	fontSize: 19,
-	marginLeft: 20,
-	marginBottom: 20,
-	color: theme.text.menu,
+  fontSize: 19,
+  marginLeft: 20,
+  marginBottom: 20,
+  color: theme.text.menu,
 }));

--- a/App/lib/hooks/useBible.js
+++ b/App/lib/hooks/useBible.js
@@ -5,7 +5,7 @@ import english from 'assets/translations/english.json';
 import traditional from 'assets/translations/traditional.json';
 import simplified from 'assets/translations/simplified.json';
 
-import { selectors } from 'store'
+import { selectors } from 'store';
 
 const languages = {
   english,
@@ -14,26 +14,26 @@ const languages = {
 };
 
 const testMap = {
-  old: "Old Testament",
-  new: "New Testament",
+  old: 'Old Testament',
+  new: 'New Testament',
 };
 
 const books = {
-  old: ["Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy", "Joshua", "Judges", "Ruth", "1 Samuel", "2 Samuel", "1 Kings", "2 Kings", "1 Chronicles", "2 Chronicles", "Ezra", "Nehemiah", "Esther", "Job", "Psalms", "Proverbs", "Ecclesiastes", "Song of Solomon", "Isaiah", "Jeremiah", "Lamentations", "Ezekiel", "Daniel", "Hosea", "Joel", "Amos", "Obadiah", "Jonah", "Micah", "Nahum", "Habakkuk", "Zephaniah", "Haggai", "Zechariah", "Malachi"],
-  new: ["Matthew", "Mark", "Luke", "John", "Acts", "Romans", "1 Corinthians", "2 Corinthians", "Galatians", "Ephesians", "Philippians", "Colossians", "1 Thessalonians", "2 Thessalonians", "1 Timothy", "2 Timothy", "Titus", "Philemon", "Hebrews", "James", "1 Peter", "2 Peter", "1 John", "2 John", "3 John", "Jude", "Revelation"]
-}
+  old: ['Genesis', 'Exodus', 'Leviticus', 'Numbers', 'Deuteronomy', 'Joshua', 'Judges', 'Ruth', '1 Samuel', '2 Samuel', '1 Kings', '2 Kings', '1 Chronicles', '2 Chronicles', 'Ezra', 'Nehemiah', 'Esther', 'Job', 'Psalms', 'Proverbs', 'Ecclesiastes', 'Song of Solomon', 'Isaiah', 'Jeremiah', 'Lamentations', 'Ezekiel', 'Daniel', 'Hosea', 'Joel', 'Amos', 'Obadiah', 'Jonah', 'Micah', 'Nahum', 'Habakkuk', 'Zephaniah', 'Haggai', 'Zechariah', 'Malachi'],
+  new: ['Matthew', 'Mark', 'Luke', 'John', 'Acts', 'Romans', '1 Corinthians', '2 Corinthians', 'Galatians', 'Ephesians', 'Philippians', 'Colossians', '1 Thessalonians', '2 Thessalonians', '1 Timothy', '2 Timothy', 'Titus', 'Philemon', 'Hebrews', 'James', '1 Peter', '2 Peter', '1 John', '2 John', '3 John', 'Jude', 'Revelation']
+};
 
-const allBooks = [...books.old, ...books.new]
+const allBooks = [...books.old, ...books.new];
 
 export default function useBible(initialState) {
   const language = useSelector(selectors.language);
   const bible = languages[language];
 
-  const [testament, innerSetTestament] = useState(initialState?.testament || "old"); // new
+  const [testament, innerSetTestament] = useState(initialState?.testament || 'old'); // new
   const testKey = testMap[testament];
-  const [book, innerSetBook] = useState(initialState?.book ?? null)
-  const [chapter, innerSetChapter] = useState(initialState?.chapter ?? null)
-  const verses = bible[testKey]?.[book]?.[chapter] || []
+  const [book, innerSetBook] = useState(initialState?.book ?? null);
+  const [chapter, innerSetChapter] = useState(initialState?.chapter ?? null);
+  const verses = bible[testKey]?.[book]?.[chapter] || [];
 
   function nextChapter() {
     let nextChapter = chapter + 1;
@@ -102,22 +102,22 @@ export default function useBible(initialState) {
   function setBook(payload) {
     // TODO: allow book names?
     if (payload === null || payload === undefined) {
-      innerSetBook(null)
-      innerSetChapter(null)
+      innerSetBook(null);
+      innerSetChapter(null);
     }
     const isValid = (bible?.[testKey]?.[payload] || 0).length > 0;
     if (!isValid) return;
-    innerSetBook(payload)
+    innerSetBook(payload);
   }
 
   function setChapter(payload) {
     // TODO: allow book names
     if (payload === null || payload === undefined) {
-      innerSetChapter(null)
+      innerSetChapter(null);
     }
     const isValid = !!bible?.[testKey]?.[book]?.[payload];
     if (!isValid) return;
-    innerSetChapter(payload)
+    innerSetChapter(payload);
   }
 
   return {
@@ -132,5 +132,5 @@ export default function useBible(initialState) {
     verses, // array of verses
     nextChapter,
     prevChapter,
-  }
+  };
 }

--- a/App/lib/hooks/useBible.js
+++ b/App/lib/hooks/useBible.js
@@ -19,11 +19,77 @@ const testMap = {
 };
 
 const books = {
-  old: ['Genesis', 'Exodus', 'Leviticus', 'Numbers', 'Deuteronomy', 'Joshua', 'Judges', 'Ruth', '1 Samuel', '2 Samuel', '1 Kings', '2 Kings', '1 Chronicles', '2 Chronicles', 'Ezra', 'Nehemiah', 'Esther', 'Job', 'Psalms', 'Proverbs', 'Ecclesiastes', 'Song of Solomon', 'Isaiah', 'Jeremiah', 'Lamentations', 'Ezekiel', 'Daniel', 'Hosea', 'Joel', 'Amos', 'Obadiah', 'Jonah', 'Micah', 'Nahum', 'Habakkuk', 'Zephaniah', 'Haggai', 'Zechariah', 'Malachi'],
-  new: ['Matthew', 'Mark', 'Luke', 'John', 'Acts', 'Romans', '1 Corinthians', '2 Corinthians', 'Galatians', 'Ephesians', 'Philippians', 'Colossians', '1 Thessalonians', '2 Thessalonians', '1 Timothy', '2 Timothy', 'Titus', 'Philemon', 'Hebrews', 'James', '1 Peter', '2 Peter', '1 John', '2 John', '3 John', 'Jude', 'Revelation']
+  old: [
+    'Genesis',
+    'Exodus',
+    'Leviticus',
+    'Numbers',
+    'Deuteronomy',
+    'Joshua',
+    'Judges',
+    'Ruth',
+    '1 Samuel',
+    '2 Samuel',
+    '1 Kings',
+    '2 Kings',
+    '1 Chronicles',
+    '2 Chronicles',
+    'Ezra',
+    'Nehemiah',
+    'Esther',
+    'Job',
+    'Psalms',
+    'Proverbs',
+    'Ecclesiastes',
+    'Song of Solomon',
+    'Isaiah',
+    'Jeremiah',
+    'Lamentations',
+    'Ezekiel',
+    'Daniel',
+    'Hosea',
+    'Joel',
+    'Amos',
+    'Obadiah',
+    'Jonah',
+    'Micah',
+    'Nahum',
+    'Habakkuk',
+    'Zephaniah',
+    'Haggai',
+    'Zechariah',
+    'Malachi'
+  ],
+  new: [
+    'Matthew',
+    'Mark',
+    'Luke',
+    'John',
+    'Acts',
+    'Romans',
+    '1 Corinthians',
+    '2 Corinthians',
+    'Galatians',
+    'Ephesians',
+    'Philippians',
+    'Colossians',
+    '1 Thessalonians',
+    '2 Thessalonians',
+    '1 Timothy',
+    '2 Timothy',
+    'Titus',
+    'Philemon',
+    'Hebrews',
+    'James',
+    '1 Peter',
+    '2 Peter',
+    '1 John',
+    '2 John',
+    '3 John',
+    'Jude',
+    'Revelation'
+  ]
 };
-
-const allBooks = [...books.old, ...books.new];
 
 export default function useBible(initialState) {
   const language = useSelector(selectors.language);
@@ -64,13 +130,13 @@ export default function useBible(initialState) {
     let prevChapter = chapter - 1;
     let prevBook = book;
     let prevTest = testament;
-    
+
     // maybe go to prev book
     if (prevChapter < 0) {
       prevBook -= 1;
       prevChapter = (bible[testKey][prevBook]?.length || 0) - 1;
     }
-    
+
     // maybe go to prev testament
     if (prevBook < 0) {
       prevTest = prevTest === 'new' ? 'old' : null;

--- a/App/lib/hooks/useIsMounted.js
+++ b/App/lib/hooks/useIsMounted.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-len
 // https://stackoverflow.com/questions/53179075/with-useeffect-how-can-i-skip-applying-an-effect-upon-the-initial-render
 import { useRef, useEffect } from 'react';
 

--- a/App/lib/hooks/useIsMounted.js
+++ b/App/lib/hooks/useIsMounted.js
@@ -7,4 +7,4 @@ export default function useIsMounted() {
     isMountRef.current = true;
   }, []);
   return isMountRef.current;
-};
+}

--- a/App/lib/hooks/usePersistStore.js
+++ b/App/lib/hooks/usePersistStore.js
@@ -16,7 +16,7 @@ export default function usePersistStore() {
 
     return () => {
       saveStore();
-    }
+    };
   }, []);
 
   useEffect(() => {
@@ -28,21 +28,21 @@ export default function usePersistStore() {
   }, [appState]);
   
   function saveStore() {
-    const jsonValue = JSON.stringify(state)
+    const jsonValue = JSON.stringify(state);
     AsyncStorage.setItem('@storage_Key', jsonValue).catch(err => {
       console.log(err);
-    })
+    });
   }
 
   function retrieveStore() {
     AsyncStorage.getItem('@storage_Key').then(jsonValue => {
       const newState = jsonValue != null ? JSON.parse(jsonValue) : initialState;
       dispatch({
-        type: "REHYDRATE_STORE",
+        type: 'REHYDRATE_STORE',
         payload: newState,
       });
     }).catch(err => {
       console.log(err);
-    })
+    });
   }
 }

--- a/App/lib/hooks/usePersistStore.js
+++ b/App/lib/hooks/usePersistStore.js
@@ -22,11 +22,11 @@ export default function usePersistStore() {
   useEffect(() => {
     if (!isMounted) return;
     if ('active' === appState) return;
-    
+
     // 'background' || 'inactive
     saveStore();
   }, [appState]);
-  
+
   function saveStore() {
     const jsonValue = JSON.stringify(state);
     AsyncStorage.setItem('@storage_Key', jsonValue).catch(err => {
@@ -36,7 +36,7 @@ export default function usePersistStore() {
 
   function retrieveStore() {
     AsyncStorage.getItem('@storage_Key').then(jsonValue => {
-      const newState = jsonValue != null ? JSON.parse(jsonValue) : initialState;
+      const newState = jsonValue != null ? JSON.parse(jsonValue) : {};
       dispatch({
         type: 'REHYDRATE_STORE',
         payload: newState,

--- a/App/navigation/DrawerNavigator.js
+++ b/App/navigation/DrawerNavigator.js
@@ -1,17 +1,17 @@
-import { createDrawerNavigator } from "react-navigation-drawer";
+import { createDrawerNavigator } from 'react-navigation-drawer';
 
-import Drawer from "screens/Drawer";
-import MainNavigator from "navigation/MainNavigator"
+import Drawer from 'screens/Drawer';
+import MainNavigator from 'navigation/MainNavigator';
 
 const DrawerNavigator = createDrawerNavigator(
-    {
-        Main: MainNavigator,
-    },
-    {
-        initialRouteName: "Main",
-        drawerWidth: "86%",
-        contentComponent: Drawer,
-    }
+  {
+    Main: MainNavigator,
+  },
+  {
+    initialRouteName: 'Main',
+    drawerWidth: '86%',
+    contentComponent: Drawer,
+  }
 );
 
 export default DrawerNavigator;

--- a/App/navigation/MainNavigator.js
+++ b/App/navigation/MainNavigator.js
@@ -1,160 +1,160 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { Share } from "react-native";
-import * as MailComposer from "expo-mail-composer";
-import { NavigationContainer } from "@react-navigation/native";
-import { createStackNavigator } from "@react-navigation/stack";
-import { useTheme } from "emotion-theming";
-import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
-import styled from "@emotion/native";
+import { Share } from 'react-native';
+import * as MailComposer from 'expo-mail-composer';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+import { useTheme } from 'emotion-theming';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import styled from '@emotion/native';
 
-import Bible from "screens/Bible";
+import Bible from 'screens/Bible';
 import { useBible } from 'lib/hooks';
-import { selectors } from "store";
+import { selectors } from 'store';
 
 const Stack = createStackNavigator();
 
 export default function MainNavigator({ navigation }) {
 	  const { background } = useTheme();
-		const [showDropdown, setShowDropdown] = useState(false);
-		const { books, setTestament } = useBible();
-		const { testament, book, chapter } = useSelector(selectors.currentScripture);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const { books, setTestament } = useBible();
+  const { testament, book, chapter } = useSelector(selectors.currentScripture);
 		
-		useEffect(() => {
-			setTestament(testament);
-		}, [testament]);
+  useEffect(() => {
+    setTestament(testament);
+  }, [testament]);
 
-		return (
-        <NavigationContainer>
-            <Stack.Navigator
-                screenOptions={{
-                    headerStyle: {
-                        backgroundColor: background.navbar,
-                        shadowColor: "transparent",
-                    },
-                    headerLeft: () => <HeaderLeft navigation={navigation} />,
-                    headerRight: () => <HeaderRight navigation={navigation} dropdownState={[showDropdown, setShowDropdown]} />,
-                    headerTitle: <Title>{`${books[book]} ${chapter + 1}`}</Title>,
-                }}
-            >
-                <Stack.Screen name="Bible" component={Bible} />
-            </Stack.Navigator>
-        </NavigationContainer>
-    );
-};
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          headerStyle: {
+            backgroundColor: background.navbar,
+            shadowColor: 'transparent',
+          },
+          headerLeft: () => <HeaderLeft navigation={navigation} />,
+          headerRight: () => <HeaderRight navigation={navigation} dropdownState={[showDropdown, setShowDropdown]} />,
+          headerTitle: <Title>{`${books[book]} ${chapter + 1}`}</Title>,
+        }}
+      >
+        <Stack.Screen name="Bible" component={Bible} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
 
 function HeaderRight({ dropdownState, navigation }) {
-	const { text } = useTheme();
-	const [showDropdown, setShowDropdown] = dropdownState;
-	const onShare = async () => {
-		try {
-				const result = await Share.share({
-						url: "https://github.com/House-of-Faith/RN-Chinese-Bible",
-				});
-				if (result.action === Share.sharedAction) {
-						if (result.activityType) {
-								// shared with activity type of result.activityType
-						} else {
-								// shared
-						}
-				} else if (result.action === Share.dismissedAction) {
-						// dismissed
-				}
-		} catch (error) {
-				alert(error.message);
-		}
-};
+  const { text } = useTheme();
+  const [showDropdown, setShowDropdown] = dropdownState;
+  const onShare = async () => {
+    try {
+      const result = await Share.share({
+        url: 'https://github.com/House-of-Faith/RN-Chinese-Bible',
+      });
+      if (result.action === Share.sharedAction) {
+        if (result.activityType) {
+          // shared with activity type of result.activityType
+        } else {
+          // shared
+        }
+      } else if (result.action === Share.dismissedAction) {
+        // dismissed
+      }
+    } catch (error) {
+      alert(error.message);
+    }
+  };
 
-	const onFeedback = async () => {
-			try {
-					const result = await MailComposer.isAvailableAsync();
-					console.log(result);
+  const onFeedback = async () => {
+    try {
+      const result = await MailComposer.isAvailableAsync();
+      console.log(result);
 
-					if (result) {
-							MailComposer.composeAsync({
-									recipients: ["feedback@houseof.faith"],
-									subject: "",
-									body: "",
-							});
-					} else {
-							alert("Error");
-					}
-			} catch (error) {
-					alert(error.message);
-			}
-	};
+      if (result) {
+        MailComposer.composeAsync({
+          recipients: ['feedback@houseof.faith'],
+          subject: '',
+          body: '',
+        });
+      } else {
+        alert('Error');
+      }
+    } catch (error) {
+      alert(error.message);
+    }
+  };
 
-	return (
-		<HamburgerMenu
-				onPress={() => {
-						setShowDropdown(!showDropdown);
-				}}
-		>
-				<Icon
-						name="dots-vertical"
-						size={21}
-						color={text.navbar}
-				/>
-				{showDropdown && (
-						<MenuContainer>
-								<MenuItem onPress={onShare}>
-										<MenuText>Share</MenuText>
-								</MenuItem>
-								<MenuItem
-										onPress={() =>
-												navigation.navigate("Settings")
-										}
-								>
-										<MenuText>Settings</MenuText>
-								</MenuItem>
-								<MenuItem onPress={onFeedback}>
-										<MenuText>Feedback</MenuText>
-								</MenuItem>
-						</MenuContainer>
-				)}
-		</HamburgerMenu>
-	);
-};
+  return (
+    <HamburgerMenu
+      onPress={() => {
+        setShowDropdown(!showDropdown);
+      }}
+    >
+      <Icon
+        name="dots-vertical"
+        size={21}
+        color={text.navbar}
+      />
+      {showDropdown && (
+        <MenuContainer>
+          <MenuItem onPress={onShare}>
+            <MenuText>Share</MenuText>
+          </MenuItem>
+          <MenuItem
+            onPress={() =>
+              navigation.navigate('Settings')
+            }
+          >
+            <MenuText>Settings</MenuText>
+          </MenuItem>
+          <MenuItem onPress={onFeedback}>
+            <MenuText>Feedback</MenuText>
+          </MenuItem>
+        </MenuContainer>
+      )}
+    </HamburgerMenu>
+  );
+}
 
 const HamburgerMenu = styled.TouchableOpacity(({ theme }) => ({
-	paddingRight: 19,
+  paddingRight: 19,
 }));
 
 function HeaderLeft({ navigation }) {
-	const { text } = useTheme();
-	return (
-		<DotMenu onPress={() => navigation.toggleDrawer()}>
-			<Icon name="menu" size={22} color={text.navbar} />
-		</DotMenu>
-	);
-};
+  const { text } = useTheme();
+  return (
+    <DotMenu onPress={() => navigation.toggleDrawer()}>
+      <Icon name="menu" size={22} color={text.navbar} />
+    </DotMenu>
+  );
+}
 
 const DotMenu = styled.TouchableOpacity(({ theme }) => ({
-	marginLeft: 19,
+  marginLeft: 19,
 }));
 
 const Title = styled.Text(({ theme }) => ({
-	fontSize: 22,
-	color: "#ffffff",
+  fontSize: 22,
+  color: '#ffffff',
 }));
 
 const MenuContainer = styled.View(({ theme }) => ({
-	position: "absolute",
-	top: -7,
-	right: 10,
-	height: 153,
-	width: 125,
-	backgroundColor: theme.background.menu,
-	paddingLeft: 20,
-	paddingTop: 20,
+  position: 'absolute',
+  top: -7,
+  right: 10,
+  height: 153,
+  width: 125,
+  backgroundColor: theme.background.menu,
+  paddingLeft: 20,
+  paddingTop: 20,
 }));
 
 const MenuItem = styled.TouchableOpacity(({ theme }) => ({
-	width: 88,
-	marginBottom: 20,
+  width: 88,
+  marginBottom: 20,
 }));
 
 const MenuText = styled.Text(({ theme }) => ({
-	fontSize: 20,
-	color: theme.text.menu,
+  fontSize: 20,
+  color: theme.text.menu,
 }));

--- a/App/navigation/MainNavigator.js
+++ b/App/navigation/MainNavigator.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { Share } from 'react-native';
 import * as MailComposer from 'expo-mail-composer';
@@ -15,11 +16,11 @@ import { selectors } from 'store';
 const Stack = createStackNavigator();
 
 export default function MainNavigator({ navigation }) {
-	  const { background } = useTheme();
+  const { background } = useTheme();
   const [showDropdown, setShowDropdown] = useState(false);
   const { books, setTestament } = useBible();
   const { testament, book, chapter } = useSelector(selectors.currentScripture);
-		
+
   useEffect(() => {
     setTestament(testament);
   }, [testament]);
@@ -32,8 +33,12 @@ export default function MainNavigator({ navigation }) {
             backgroundColor: background.navbar,
             shadowColor: 'transparent',
           },
+          // eslint-disable-next-line react/display-name
           headerLeft: () => <HeaderLeft navigation={navigation} />,
-          headerRight: () => <HeaderRight navigation={navigation} dropdownState={[showDropdown, setShowDropdown]} />,
+          // eslint-disable-next-line react/display-name
+          headerRight: () => (
+            <HeaderRight navigation={navigation} dropdownState={[showDropdown, setShowDropdown]} />
+          ),
           headerTitle: <Title>{`${books[book]} ${chapter + 1}`}</Title>,
         }}
       >
@@ -42,6 +47,10 @@ export default function MainNavigator({ navigation }) {
     </NavigationContainer>
   );
 }
+
+MainNavigator.propTypes = {
+  navigation: PropTypes.object
+};
 
 function HeaderRight({ dropdownState, navigation }) {
   const { text } = useTheme();
@@ -116,7 +125,12 @@ function HeaderRight({ dropdownState, navigation }) {
   );
 }
 
-const HamburgerMenu = styled.TouchableOpacity(({ theme }) => ({
+HeaderRight.propTypes = {
+  dropdownState: PropTypes.array,
+  navigation: PropTypes.object
+};
+
+const HamburgerMenu = styled.TouchableOpacity(() => ({
   paddingRight: 19,
 }));
 
@@ -129,11 +143,15 @@ function HeaderLeft({ navigation }) {
   );
 }
 
-const DotMenu = styled.TouchableOpacity(({ theme }) => ({
+HeaderLeft.propTypes = {
+  navigation: PropTypes.object
+};
+
+const DotMenu = styled.TouchableOpacity(() => ({
   marginLeft: 19,
 }));
 
-const Title = styled.Text(({ theme }) => ({
+const Title = styled.Text(() => ({
   fontSize: 22,
   color: '#ffffff',
 }));
@@ -149,7 +167,7 @@ const MenuContainer = styled.View(({ theme }) => ({
   paddingTop: 20,
 }));
 
-const MenuItem = styled.TouchableOpacity(({ theme }) => ({
+const MenuItem = styled.TouchableOpacity(() => ({
   width: 88,
   marginBottom: 20,
 }));

--- a/App/navigation/MainNavigator.js
+++ b/App/navigation/MainNavigator.js
@@ -126,8 +126,12 @@ function HeaderRight({ dropdownState, navigation }) {
 }
 
 HeaderRight.propTypes = {
-  dropdownState: PropTypes.array,
-  navigation: PropTypes.object
+  dropdownState: PropTypes.arrayOf(([val, func], _key, componentName, _location, propFullName) => {
+    if (!(typeof val === 'boolean' && typeof func === 'function')) {
+      return new Error(`Invalid prop ${propFullName} supplied to ${componentName}!`);
+    }
+  }).isRequired,
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired }).isRequired
 };
 
 const HamburgerMenu = styled.TouchableOpacity(() => ({

--- a/App/navigation/RootNavigation.js
+++ b/App/navigation/RootNavigation.js
@@ -1,13 +1,13 @@
-import { createAppContainer, createSwitchNavigator } from "react-navigation";
+import { createAppContainer, createSwitchNavigator } from 'react-navigation';
 
-import SettingsNavigator from "navigation/SettingsNavigator";
-import DrawerNavigator from "navigation/DrawerNavigator";
+import SettingsNavigator from 'navigation/SettingsNavigator';
+import DrawerNavigator from 'navigation/DrawerNavigator';
 
 const App = createAppContainer(
-    createSwitchNavigator({
-        Main: DrawerNavigator,
-        Settings: SettingsNavigator,
-    })
+  createSwitchNavigator({
+    Main: DrawerNavigator,
+    Settings: SettingsNavigator,
+  })
 );
 
 const AppNavigation = createAppContainer(App);

--- a/App/navigation/SettingsNavigator.js
+++ b/App/navigation/SettingsNavigator.js
@@ -47,7 +47,7 @@ export default function SettingsNavigator({ navigation }) {
 }
 
 SettingsNavigator.propTypes = {
-  navigation: PropTypes.object
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired }).isRequired
 };
 
 const Title = styled.Text(({ theme }) => ({

--- a/App/navigation/SettingsNavigator.js
+++ b/App/navigation/SettingsNavigator.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { NavigationContainer } from '@react-navigation/native';
 import { useTheme } from 'emotion-theming';
 import { createStackNavigator } from '@react-navigation/stack';
@@ -17,6 +18,7 @@ export default function SettingsNavigator({ navigation }) {
     <NavigationContainer>
       <Stack.Navigator
         screenOptions={{
+          // eslint-disable-next-line react/display-name
           headerLeft: () => (
             <TouchableOpacity
               onPress={() => {
@@ -43,6 +45,10 @@ export default function SettingsNavigator({ navigation }) {
     </NavigationContainer>
   );
 }
+
+SettingsNavigator.propTypes = {
+  navigation: PropTypes.object
+};
 
 const Title = styled.Text(({ theme }) => ({
   fontSize: 22,

--- a/App/navigation/SettingsNavigator.js
+++ b/App/navigation/SettingsNavigator.js
@@ -1,50 +1,50 @@
-import React from "react";
-import { NavigationContainer } from "@react-navigation/native";
-import { useTheme } from "emotion-theming";
-import { createStackNavigator } from "@react-navigation/stack";
-import { TouchableOpacity } from "react-native-gesture-handler";
-import { MaterialCommunityIcons as Icon } from "@expo/vector-icons";
-import styled from "@emotion/native";
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { useTheme } from 'emotion-theming';
+import { createStackNavigator } from '@react-navigation/stack';
+import { TouchableOpacity } from 'react-native-gesture-handler';
+import { MaterialCommunityIcons as Icon } from '@expo/vector-icons';
+import styled from '@emotion/native';
 
 import Settings from 'screens/Settings';
 
 const Stack = createStackNavigator();
 
 export default function SettingsNavigator({ navigation }) {
-    const { background, text } = useTheme();
+  const { background, text } = useTheme();
 
-    return (
-        <NavigationContainer>
-            <Stack.Navigator
-                screenOptions={{
-                    headerLeft: () => (
-                        <TouchableOpacity
-                            onPress={() => {
-                                navigation.navigate("Main");
-                            }}
-                            style={{ marginLeft: 19 }}
-                        >
-                            <Icon
-                                name="arrow-left"
-                                size={24}
-                                color={text.navbar}
-                            />
-                        </TouchableOpacity>
-                    ),
-                    headerStyle: {
-                        backgroundColor: background.navbar,
-                        shadowColor: "transparent",
-                    },
-                    headerTitle: <Title>Settings</Title>,
-                }}
+  return (
+    <NavigationContainer>
+      <Stack.Navigator
+        screenOptions={{
+          headerLeft: () => (
+            <TouchableOpacity
+              onPress={() => {
+                navigation.navigate('Main');
+              }}
+              style={{ marginLeft: 19 }}
             >
-                <Stack.Screen name="Settings" component={Settings} />
-            </Stack.Navigator>
-        </NavigationContainer>
-    );
-};
+              <Icon
+                name="arrow-left"
+                size={24}
+                color={text.navbar}
+              />
+            </TouchableOpacity>
+          ),
+          headerStyle: {
+            backgroundColor: background.navbar,
+            shadowColor: 'transparent',
+          },
+          headerTitle: <Title>Settings</Title>,
+        }}
+      >
+        <Stack.Screen name="Settings" component={Settings} />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
 
 const Title = styled.Text(({ theme }) => ({
-    fontSize: 22,
-    color: theme.text.navbar,
+  fontSize: 22,
+  color: theme.text.navbar,
 }));

--- a/App/screens/Bible.js
+++ b/App/screens/Bible.js
@@ -33,7 +33,7 @@ export default function Main() {
     if (testament === testGlobal) return;
     setTestament(testGlobal);
   }, [testGlobal]);
-    
+
   useEffect(() => {
     if (book === bookGlobal) return;
     setBook(bookGlobal);
@@ -49,10 +49,10 @@ export default function Main() {
     setCurrentScripture({ testament, book, chapter });
   }, [testament, book, chapter]);
 
-  function setCurrentScripture({ testament = testament, book = book, chapter = chapter}) {
-    dispatch({ type: 'SET_CURRENT_SCRIPTURE', payload: { testament, book, chapter }});
+  function setCurrentScripture({ testament = testament, book = book, chapter = chapter }) {
+    dispatch({ type: 'SET_CURRENT_SCRIPTURE', payload: { testament, book, chapter } });
   }
-		
+
   const config = {
     velocityThreshold: 0.3,
     directionalOffsetThreshold: 100,
@@ -82,7 +82,7 @@ const SafeArea = styled.SafeAreaView(({ theme }) => ({
   backgroundColor: theme.background.reading,
 }));
 
-const Container = styled.ScrollView(({ theme }) => ({
+const Container = styled.ScrollView(() => ({
   paddingHorizontal: 32,
 }));
 

--- a/App/screens/Bible.js
+++ b/App/screens/Bible.js
@@ -1,89 +1,89 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import styled from "@emotion/native";
-import GestureRecognizer from "react-native-swipe-gestures";
+import styled from '@emotion/native';
+import GestureRecognizer from 'react-native-swipe-gestures';
 
 import { selectors } from 'store';
 import { useBible, useIsMounted } from 'lib/hooks';
-import Chapter from "components/Bible/Chapter";
+import Chapter from 'components/Bible/Chapter';
 
 export default function Main() {
-    const ref = useRef(null);
+  const ref = useRef(null);
 
-		const isMounted = useIsMounted();
-    const dispatch = useDispatch()
-    const {
-      testament: testGlobal,
-      book: bookGlobal,
-      chapter: chapterGlobal,
-    } = useSelector(selectors.currentScripture);
-    const {
-      testament, // old/new
-      setTestament,
-      book, // index
-      setBook,
-      chapter, // index
-      setChapter,
-      verses, // array of verses
-      nextChapter,
-			prevChapter,
-    } = useBible({ testament: testGlobal, book: bookGlobal, chapter: chapterGlobal });
+  const isMounted = useIsMounted();
+  const dispatch = useDispatch();
+  const {
+    testament: testGlobal,
+    book: bookGlobal,
+    chapter: chapterGlobal,
+  } = useSelector(selectors.currentScripture);
+  const {
+    testament, // old/new
+    setTestament,
+    book, // index
+    setBook,
+    chapter, // index
+    setChapter,
+    verses, // array of verses
+    nextChapter,
+    prevChapter,
+  } = useBible({ testament: testGlobal, book: bookGlobal, chapter: chapterGlobal });
 
-    useEffect(() => {
-      if (testament === testGlobal) return;
-      setTestament(testGlobal)
-    }, [testGlobal])
+  useEffect(() => {
+    if (testament === testGlobal) return;
+    setTestament(testGlobal);
+  }, [testGlobal]);
     
-    useEffect(() => {
-      if (book === bookGlobal) return;
-      setBook(bookGlobal)
-    }, [bookGlobal])
+  useEffect(() => {
+    if (book === bookGlobal) return;
+    setBook(bookGlobal);
+  }, [bookGlobal]);
 
-    useEffect(() => {
-      if (chapter === chapterGlobal) return;
-      setChapter(chapterGlobal)
-    }, [chapterGlobal])
+  useEffect(() => {
+    if (chapter === chapterGlobal) return;
+    setChapter(chapterGlobal);
+  }, [chapterGlobal]);
 
-    useEffect(() => {
-      if (!isMounted) return
-      setCurrentScripture({ testament, book, chapter })
-    }, [testament, book, chapter])
+  useEffect(() => {
+    if (!isMounted) return;
+    setCurrentScripture({ testament, book, chapter });
+  }, [testament, book, chapter]);
 
-    function setCurrentScripture({ testament = testament, book = book, chapter = chapter}) {
-      dispatch({ type: "SET_CURRENT_SCRIPTURE", payload: { testament, book, chapter }})
-		}
+  function setCurrentScripture({ testament = testament, book = book, chapter = chapter}) {
+    dispatch({ type: 'SET_CURRENT_SCRIPTURE', payload: { testament, book, chapter }});
+  }
 		
-    const config = {
-        velocityThreshold: 0.3,
-        directionalOffsetThreshold: 100,
-    };
+  const config = {
+    velocityThreshold: 0.3,
+    directionalOffsetThreshold: 100,
+  };
 
-    useEffect(() => {
-        if (ref?.current) ref.current.scrollTo({ y: 0 });
-    }, [verses]);
+  useEffect(() => {
+    if (ref?.current) ref.current.scrollTo({ y: 0 });
+  }, [verses]);
 
-    return (
-        <SafeArea>
-            <Container ref={ref}>
-                <GestureRecognizer
-                    onSwipeLeft={nextChapter}
-                    onSwipeRight={prevChapter}
-                    config={config}
-                >
-                    <Spacer />
-                    <Chapter verses={verses} />
-                </GestureRecognizer>
-            </Container>
-        </SafeArea>
-    );
-};
+  return (
+    <SafeArea>
+      <Container ref={ref}>
+        <GestureRecognizer
+          onSwipeLeft={nextChapter}
+          onSwipeRight={prevChapter}
+          config={config}
+        >
+          <Spacer />
+          <Chapter verses={verses} />
+        </GestureRecognizer>
+      </Container>
+    </SafeArea>
+  );
+}
 
 const SafeArea = styled.SafeAreaView(({ theme }) => ({
-    backgroundColor: theme.background.reading,
+  backgroundColor: theme.background.reading,
 }));
 
 const Container = styled.ScrollView(({ theme }) => ({
-    paddingHorizontal: 32,
+  paddingHorizontal: 32,
 }));
 
 const Spacer = styled.View({ height: 30 });

--- a/App/screens/Drawer.js
+++ b/App/screens/Drawer.js
@@ -88,7 +88,7 @@ export default function Drawer({ navigation }) {
 }
 
 Drawer.propTypes = {
-  navigation: PropTypes.object.isRequired
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired }).isRequired
 };
 
 const BookSelected = styled.View(() => ({

--- a/App/screens/Drawer.js
+++ b/App/screens/Drawer.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useDispatch } from 'react-redux';
 import {
   ScrollView,
@@ -37,7 +38,7 @@ export default function Drawer({ navigation }) {
         }}
       >
         <DrawerHeader
-								    testament={testament}
+          testament={testament}
           onPress={(newTest) => {
             setBook(null);
             setTestament(newTest);
@@ -45,7 +46,7 @@ export default function Drawer({ navigation }) {
         />
         {book !== null ? (
           <BookSelected>
-											  <BookTitle
+            <BookTitle
               onPress={() => setBook(null)}
               book={books[book]}
               isSelected
@@ -86,13 +87,17 @@ export default function Drawer({ navigation }) {
   );
 }
 
-const BookSelected = styled.View(({ theme }) => ({
+Drawer.propTypes = {
+  navigation: PropTypes.object
+};
+
+const BookSelected = styled.View(() => ({
   display: 'flex',
   flexDirection: 'row',
   flexWrap: 'wrap',
 }));
 
-const ReturnContainer = styled.TouchableOpacity(({ theme }) => ({
+const ReturnContainer = styled.TouchableOpacity(() => ({
   display: 'flex',
   flexDirection: 'row',
   justifyContent: 'flex-start',

--- a/App/screens/Drawer.js
+++ b/App/screens/Drawer.js
@@ -88,7 +88,7 @@ export default function Drawer({ navigation }) {
 }
 
 Drawer.propTypes = {
-  navigation: PropTypes.object
+  navigation: PropTypes.object.isRequired
 };
 
 const BookSelected = styled.View(() => ({

--- a/App/screens/Drawer.js
+++ b/App/screens/Drawer.js
@@ -1,109 +1,109 @@
-import React from "react";
-import { useDispatch } from "react-redux";
+import React from 'react';
+import { useDispatch } from 'react-redux';
 import {
-    ScrollView,
-    SafeAreaView,
-} from "react-native";
-import { useTheme } from "emotion-theming";
-import styled from "@emotion/native";
-import { AntDesign as Icon } from "@expo/vector-icons";
+  ScrollView,
+  SafeAreaView,
+} from 'react-native';
+import { useTheme } from 'emotion-theming';
+import styled from '@emotion/native';
+import { AntDesign as Icon } from '@expo/vector-icons';
 
-import DrawerHeader from "components/Drawer/DrawerHeader";
-import BookList from "components/Drawer/BookList";
-import BookTitle from "components/Drawer/BookTitle";
-import ChapterList from "components/Drawer/ChapterList";
-import { useBible } from "lib/hooks";
+import DrawerHeader from 'components/Drawer/DrawerHeader';
+import BookList from 'components/Drawer/BookList';
+import BookTitle from 'components/Drawer/BookTitle';
+import ChapterList from 'components/Drawer/ChapterList';
+import { useBible } from 'lib/hooks';
 
 export default function Drawer({ navigation }) {
-    const dispatch = useDispatch()
-    const { background, text } = useTheme();
-    const {
-      testament, // old/new
-      setTestament,
-      book, // index
-      books, // array of book names
-      setBook,
-      chapters, // integer
-    } = useBible({ book: null, chapter: null });
+  const dispatch = useDispatch();
+  const { background, text } = useTheme();
+  const {
+    testament, // old/new
+    setTestament,
+    book, // index
+    books, // array of book names
+    setBook,
+    chapters, // integer
+  } = useBible({ book: null, chapter: null });
 
-    return (
-        <SafeAreaView
-            style={{ height: "100%", backgroundColor: background.menu }}
-        >
-            <ScrollView
-                style={{
-                    marginTop: 7,
-                    marginHorizontal: 20,
-                }}
-            >
-								<DrawerHeader
+  return (
+    <SafeAreaView
+      style={{ height: '100%', backgroundColor: background.menu }}
+    >
+      <ScrollView
+        style={{
+          marginTop: 7,
+          marginHorizontal: 20,
+        }}
+      >
+        <DrawerHeader
 								    testament={testament}
-										onPress={(newTest) => {
-											setBook(null);
-											setTestament(newTest);
-									}}
-								/>
-                {book !== null ? (
-                    <BookSelected>
+          onPress={(newTest) => {
+            setBook(null);
+            setTestament(newTest);
+          }}
+        />
+        {book !== null ? (
+          <BookSelected>
 											  <BookTitle
-														onPress={() => setBook(null)}
-														book={books[book]}
-														isSelected
-												/>
-												<ChapterList
-														chapters={chapters}
-														onSelectChapter={(selected) => {
-															dispatch({
-																type: "SET_CURRENT_SCRIPTURE",
-																payload: { testament, book, chapter: selected },
-															})
-															navigation.closeDrawer();
-															// setBook(null);
-														}}
-												/>
-                        <ReturnContainer
-                            onPress={() => {
-                                navigation.closeDrawer();
-                                setBook(null);
-                            }}
-                        >
-                            <Icon
-                                name="left"
-                                size={14}
-                                color={text.secondary}
-                            />
-                            <ReturnText>Return</ReturnText>
-                        </ReturnContainer>
-                    </BookSelected>
-                ) : (
-										<BookList
-												books={books}
-												onSelectBook={(selected) => setBook(selected)}
-										/>
-                )}
-            </ScrollView>
-        </SafeAreaView>
-    );
-};
+              onPress={() => setBook(null)}
+              book={books[book]}
+              isSelected
+            />
+            <ChapterList
+              chapters={chapters}
+              onSelectChapter={(selected) => {
+                dispatch({
+                  type: 'SET_CURRENT_SCRIPTURE',
+                  payload: { testament, book, chapter: selected },
+                });
+                navigation.closeDrawer();
+                // setBook(null);
+              }}
+            />
+            <ReturnContainer
+              onPress={() => {
+                navigation.closeDrawer();
+                setBook(null);
+              }}
+            >
+              <Icon
+                name="left"
+                size={14}
+                color={text.secondary}
+              />
+              <ReturnText>Return</ReturnText>
+            </ReturnContainer>
+          </BookSelected>
+        ) : (
+          <BookList
+            books={books}
+            onSelectBook={(selected) => setBook(selected)}
+          />
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
 
 const BookSelected = styled.View(({ theme }) => ({
-    display: "flex",
-    flexDirection: "row",
-    flexWrap: "wrap",
+  display: 'flex',
+  flexDirection: 'row',
+  flexWrap: 'wrap',
 }));
 
 const ReturnContainer = styled.TouchableOpacity(({ theme }) => ({
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-start",
-    alignItems: "center",
-    marginHorizontal: 10,
-    marginTop: 13,
-    width: "92%",
+  display: 'flex',
+  flexDirection: 'row',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+  marginHorizontal: 10,
+  marginTop: 13,
+  width: '92%',
 }));
 
 const ReturnText = styled.Text(({ theme }) => ({
-    fontSize: 17,
-    color: theme.text.secondary,
-    marginLeft: 5,
+  fontSize: 17,
+  color: theme.text.secondary,
+  marginLeft: 5,
 }));

--- a/App/screens/Main.js
+++ b/App/screens/Main.js
@@ -31,7 +31,7 @@ export default function Main() {
     if (testament === testGlobal) return;
     setTestament(testGlobal);
   }, [testGlobal]);
-    
+
   useEffect(() => {
     if (book === bookGlobal) return;
     setBook(bookGlobal);
@@ -47,10 +47,10 @@ export default function Main() {
     setCurrentScripture({ testament, book, chapter });
   }, [testament, book, chapter]);
 
-  function setCurrentScripture({ testament = testament, book = book, chapter = chapter}) {
-    dispatch({ type: 'SET_CURRENT_SCRIPTURE', payload: { testament, book, chapter }});
+  function setCurrentScripture({ testament = testament, book = book, chapter = chapter }) {
+    dispatch({ type: 'SET_CURRENT_SCRIPTURE', payload: { testament, book, chapter } });
   }
-    
+
   const config = {
     velocityThreshold: 0.3,
     directionalOffsetThreshold: 100,
@@ -87,7 +87,7 @@ const SafeArea = styled.SafeAreaView(({ theme }) => ({
   backgroundColor: theme.background.reading,
 }));
 
-const Container = styled.ScrollView(({ theme }) => ({
+const Container = styled.ScrollView(() => ({
   paddingHorizontal: 32,
 }));
 

--- a/App/screens/Main.js
+++ b/App/screens/Main.js
@@ -1,101 +1,101 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import styled from "@emotion/native";
-import GestureRecognizer from "react-native-swipe-gestures";
+import styled from '@emotion/native';
+import GestureRecognizer from 'react-native-swipe-gestures';
 
 import { selectors } from 'store';
 import { useBible, useIsMounted } from 'lib/hooks';
 
 export default function Main() {
-    const ref = useRef(null);
-    const isMounted = useIsMounted();
-    const dispatch = useDispatch();
-    const {
-      testament: testGlobal,
-      book: bookGlobal,
-      chapter: chapterGlobal,
-    } = useSelector(selectors.currentScripture);
-    const {
-      testament, // old/new
-      setTestament,
-      book, // index
-      setBook,
-      chapter, // index
-      setChapter,
-      verses, // array of verses
-      nextChapter,
-      prevChapter,
-    } = useBible({ testament: testGlobal, book: bookGlobal, chapter: chapterGlobal });
+  const ref = useRef(null);
+  const isMounted = useIsMounted();
+  const dispatch = useDispatch();
+  const {
+    testament: testGlobal,
+    book: bookGlobal,
+    chapter: chapterGlobal,
+  } = useSelector(selectors.currentScripture);
+  const {
+    testament, // old/new
+    setTestament,
+    book, // index
+    setBook,
+    chapter, // index
+    setChapter,
+    verses, // array of verses
+    nextChapter,
+    prevChapter,
+  } = useBible({ testament: testGlobal, book: bookGlobal, chapter: chapterGlobal });
 
-    useEffect(() => {
-      if (testament === testGlobal) return;
-      setTestament(testGlobal)
-    }, [testGlobal])
+  useEffect(() => {
+    if (testament === testGlobal) return;
+    setTestament(testGlobal);
+  }, [testGlobal]);
     
-    useEffect(() => {
-      if (book === bookGlobal) return;
-      setBook(bookGlobal)
-    }, [bookGlobal])
+  useEffect(() => {
+    if (book === bookGlobal) return;
+    setBook(bookGlobal);
+  }, [bookGlobal]);
 
-    useEffect(() => {
-      if (chapter === chapterGlobal) return;
-      setChapter(chapterGlobal)
-    }, [chapterGlobal])
+  useEffect(() => {
+    if (chapter === chapterGlobal) return;
+    setChapter(chapterGlobal);
+  }, [chapterGlobal]);
 
-    useEffect(() => {
-      if (!isMounted) return
-      setCurrentScripture({ testament, book, chapter })
-    }, [testament, book, chapter])
+  useEffect(() => {
+    if (!isMounted) return;
+    setCurrentScripture({ testament, book, chapter });
+  }, [testament, book, chapter]);
 
-    function setCurrentScripture({ testament = testament, book = book, chapter = chapter}) {
-      dispatch({ type: "SET_CURRENT_SCRIPTURE", payload: { testament, book, chapter }})
-    }
+  function setCurrentScripture({ testament = testament, book = book, chapter = chapter}) {
+    dispatch({ type: 'SET_CURRENT_SCRIPTURE', payload: { testament, book, chapter }});
+  }
     
-    const config = {
-        velocityThreshold: 0.3,
-        directionalOffsetThreshold: 100,
-    };
+  const config = {
+    velocityThreshold: 0.3,
+    directionalOffsetThreshold: 100,
+  };
 
-    useEffect(() => {
-        if (ref?.current) ref.current.scrollTo({ y: 0 });
-    }, [verses]);
+  useEffect(() => {
+    if (ref?.current) ref.current.scrollTo({ y: 0 });
+  }, [verses]);
 
 
-    return (
-        <SafeArea>
-            <Container ref={ref}>
-                <GestureRecognizer
-                    onSwipeLeft={nextChapter}
-                    onSwipeRight={prevChapter}
-                    config={config}
-                >
-                    <Spacer />
-                    {verses?.map((verse, i) => {
-                        return (
-                            <Verse key={i}>
-                                {i + 1} {verse}
-                            </Verse>
-                        );
-                    })}
-                </GestureRecognizer>
-            </Container>
-        </SafeArea>
-    );
-};
+  return (
+    <SafeArea>
+      <Container ref={ref}>
+        <GestureRecognizer
+          onSwipeLeft={nextChapter}
+          onSwipeRight={prevChapter}
+          config={config}
+        >
+          <Spacer />
+          {verses?.map((verse, i) => {
+            return (
+              <Verse key={i}>
+                {i + 1} {verse}
+              </Verse>
+            );
+          })}
+        </GestureRecognizer>
+      </Container>
+    </SafeArea>
+  );
+}
 
 const SafeArea = styled.SafeAreaView(({ theme }) => ({
-    backgroundColor: theme.background.reading,
+  backgroundColor: theme.background.reading,
 }));
 
 const Container = styled.ScrollView(({ theme }) => ({
-    paddingHorizontal: 32,
+  paddingHorizontal: 32,
 }));
 
 const Verse = styled.Text(({ theme }) => ({
-    fontSize: 19,
-    lineHeight: 27,
-    marginBottom: 13,
-    color: theme.text.reading,
+  fontSize: 19,
+  lineHeight: 27,
+  marginBottom: 13,
+  color: theme.text.reading,
 }));
 
 const Spacer = styled.View({ height: 30 });

--- a/App/screens/Settings.js
+++ b/App/screens/Settings.js
@@ -20,12 +20,12 @@ export default function Settings() {
       <SubContainer borderBottom>
         <SubTitle>THEME</SubTitle>
         <SettingsOption
-							  label="Light Theme"
+          label="Light Theme"
           selected={theme === 'light'}
           onPress={() => dispatch({ type: 'LIGHT_THEME' })}
         />
         <SettingsOption
-							  label="Dark Theme"
+          label="Dark Theme"
           selected={theme === 'dark'}
           onPress={() => dispatch({ type: 'DARK_THEME' })}
         />
@@ -34,17 +34,17 @@ export default function Settings() {
       <SubContainer borderBottom>
         <SubTitle>LANGUAGE</SubTitle>
         <SettingsOption
-							  label="English"
+          label="English"
           selected={language === 'english'}
           onPress={() => setLanguage('english')}
         />
         <SettingsOption
-							  label="Traditional Chinese"
+          label="Traditional Chinese"
           selected={language === 'traditional'}
           onPress={() => setLanguage('traditional')}
         />
         <SettingsOption
-							  label="Simplified Chinese"
+          label="Simplified Chinese"
           selected={language === 'simplified'}
           onPress={() => setLanguage('simplified')}
         />
@@ -53,9 +53,9 @@ export default function Settings() {
       <SubContainer>
         <SubTitle>ADDITIONAL INFO</SubTitle>
         <SettingsOption
-							  label="About Us"
+          label="About Us"
           selected={false}
-          onPress={() => {}}
+          onPress={() => { }}
         />
       </SubContainer>
     </Container>

--- a/App/screens/Settings.js
+++ b/App/screens/Settings.js
@@ -1,90 +1,90 @@
-import React from "react";
-import { useDispatch, useSelector } from "react-redux";
-import styled from "@emotion/native";
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import styled from '@emotion/native';
 
-import SettingsOption from "components/Settings/SettingsOption";
+import SettingsOption from 'components/Settings/SettingsOption';
 import { selectors } from 'store';
 
 export default function Settings() {
-	const theme = useSelector(selectors.theme);
-	const language = useSelector(selectors.language);
+  const theme = useSelector(selectors.theme);
+  const language = useSelector(selectors.language);
 
-	const dispatch = useDispatch();
+  const dispatch = useDispatch();
 
-	function setLanguage(lang) {
-		dispatch({ type: "SET_LANGUAGE", payload: lang });
-	}
+  function setLanguage(lang) {
+    dispatch({ type: 'SET_LANGUAGE', payload: lang });
+  }
 
-	return (
-			<Container>
-					<SubContainer borderBottom>
-							<SubTitle>THEME</SubTitle>
-							<SettingsOption
+  return (
+    <Container>
+      <SubContainer borderBottom>
+        <SubTitle>THEME</SubTitle>
+        <SettingsOption
 							  label="Light Theme"
-								selected={theme === "light"}
-								onPress={() => dispatch({ type: "LIGHT_THEME" })}
-							/>
-							<SettingsOption
+          selected={theme === 'light'}
+          onPress={() => dispatch({ type: 'LIGHT_THEME' })}
+        />
+        <SettingsOption
 							  label="Dark Theme"
-								selected={theme === "dark"}
-								onPress={() => dispatch({ type: "DARK_THEME" })}
-							/>
-					</SubContainer>
+          selected={theme === 'dark'}
+          onPress={() => dispatch({ type: 'DARK_THEME' })}
+        />
+      </SubContainer>
 
-					<SubContainer borderBottom>
-							<SubTitle>LANGUAGE</SubTitle>
-							<SettingsOption
+      <SubContainer borderBottom>
+        <SubTitle>LANGUAGE</SubTitle>
+        <SettingsOption
 							  label="English"
-								selected={language === "english"}
-								onPress={() => setLanguage("english")}
-							/>
-							<SettingsOption
+          selected={language === 'english'}
+          onPress={() => setLanguage('english')}
+        />
+        <SettingsOption
 							  label="Traditional Chinese"
-								selected={language === "traditional"}
-								onPress={() => setLanguage("traditional")}
-							/>
-							<SettingsOption
+          selected={language === 'traditional'}
+          onPress={() => setLanguage('traditional')}
+        />
+        <SettingsOption
 							  label="Simplified Chinese"
-								selected={language === "simplified"}
-								onPress={() => setLanguage("simplified")}
-							/>
-					</SubContainer>
+          selected={language === 'simplified'}
+          onPress={() => setLanguage('simplified')}
+        />
+      </SubContainer>
 
-					<SubContainer>
-							<SubTitle>ADDITIONAL INFO</SubTitle>
-							<SettingsOption
+      <SubContainer>
+        <SubTitle>ADDITIONAL INFO</SubTitle>
+        <SettingsOption
 							  label="About Us"
-								selected={false}
-								onPress={() => {}}
-							/>
-					</SubContainer>
-			</Container>
-	);
-};
+          selected={false}
+          onPress={() => {}}
+        />
+      </SubContainer>
+    </Container>
+  );
+}
 
 const Container = styled.View(({ theme }) => ({
-    backgroundColor: theme.background.menu,
-    height: "100%",
-    paddingVertical: 32,
-    paddingHorizontal: 30,
+  backgroundColor: theme.background.menu,
+  height: '100%',
+  paddingVertical: 32,
+  paddingHorizontal: 30,
 }));
 
 const SubContainer = styled.View(
-    ({ theme, borderBottom }) => {
-        if (borderBottom)
-            return {
-                borderBottomWidth: 1,
-                borderBottomColor: theme.border.color,
-            };
-    },
-    {
-        marginBottom: 20,
-    }
+  ({ theme, borderBottom }) => {
+    if (borderBottom)
+      return {
+        borderBottomWidth: 1,
+        borderBottomColor: theme.border.color,
+      };
+  },
+  {
+    marginBottom: 20,
+  }
 );
 
 const SubTitle = styled.Text(({ theme }) => ({
-    fontSize: 17,
-    fontWeight: "bold",
-    marginBottom: 20,
-    color: theme.text.menu,
+  fontSize: 17,
+  fontWeight: 'bold',
+  marginBottom: 20,
+  color: theme.text.menu,
 }));

--- a/App/store/index.js
+++ b/App/store/index.js
@@ -1,19 +1,19 @@
-import { createStore, applyMiddleware } from "redux";
+import { createStore, applyMiddleware } from 'redux';
 import reducers, { initialState } from './reducers';
 import selectors from './selectors';
 
 const middleware = ({ dispatch }) => (next) => async (action) => {
-    const { type, payload } = action;
-    switch (type) {
-        default: {
-            next(action);
-            break;
-        }
+  const { type, payload } = action;
+  switch (type) {
+    default: {
+      next(action);
+      break;
     }
+  }
 };
 
 const store = createStore(reducers, applyMiddleware(middleware));
 
 export default store;
 
-export { selectors, initialState }
+export { selectors, initialState };

--- a/App/store/index.js
+++ b/App/store/index.js
@@ -2,8 +2,8 @@ import { createStore, applyMiddleware } from 'redux';
 import reducers, { initialState } from './reducers';
 import selectors from './selectors';
 
-const middleware = ({ dispatch }) => (next) => async (action) => {
-  const { type, payload } = action;
+const middleware = () => (next) => async (action) => {
+  const { type } = action;
   switch (type) {
     default: {
       next(action);

--- a/App/store/reducers.js
+++ b/App/store/reducers.js
@@ -2,10 +2,10 @@ import { isEqual } from 'lodash';
 
 export const initialState = {
   storeRehydrated: false,
-  theme: "light",
-  language: "english", // simplified, traditional
+  theme: 'light',
+  language: 'english', // simplified, traditional
   currentScripture: {
-    testament: "old", // new
+    testament: 'old', // new
     book: 0,
     chapter: 0
   },
@@ -14,26 +14,26 @@ export const initialState = {
 export default function reducer(state = initialState, action) {
   const { type, payload } = action;
   switch (type) {
-    case "SET_CURRENT_SCRIPTURE":
+    case 'SET_CURRENT_SCRIPTURE':
       return setCurrentScripture(state, payload);
-    case "LIGHT_THEME":
-      return { ...state, theme: "light" };
-    case "DARK_THEME":
-      return { ...state, theme: "dark" };
-    case "SET_LANGUAGE":
+    case 'LIGHT_THEME':
+      return { ...state, theme: 'light' };
+    case 'DARK_THEME':
+      return { ...state, theme: 'dark' };
+    case 'SET_LANGUAGE':
       return setLanguage(state, payload);
-    case "REHYDRATE_STORE":
+    case 'REHYDRATE_STORE':
       return rehydrateStore(state, payload);
     default:
       return { ...state };
   }
-};
+}
 
 function setLanguage(state, payload) {
   const language = payload?.trim().toLowerCase();
   const isValid = ['simplified', 'traditional', 'english'].includes(language);
   if (isValid) return { ...state, language };
-  return { state }
+  return { state };
 }
 
 function setCurrentScripture(state, payload) {
@@ -49,7 +49,7 @@ function setCurrentScripture(state, payload) {
   const newScripture = payload;
   
   if (isEqual(oldScripture, newScripture)) return { ...state };
-  if (!isValid) return { ...state }
+  if (!isValid) return { ...state };
   
   return { ...state, currentScripture: newScripture };
 }

--- a/App/store/selectors.js
+++ b/App/store/selectors.js
@@ -3,4 +3,4 @@ export default {
   language: (state) => state.language || 'english',
   currentScripture: (state) => state.currentScripture || { testament: 'old', book: 0, chapter: 0 },
   storeRehydrated: (state) => state.storeRehydrated || false,
-}
+};

--- a/App/theme/AppTheme.js
+++ b/App/theme/AppTheme.js
@@ -1,15 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { ThemeProvider } from 'emotion-theming';
 
 import themes from 'theme/themes';
 import { selectors } from 'store';
 
-const AppTheme = ({ children }) => {
+export default function AppTheme({ children }) {
   const themeType = useSelector(selectors.theme);
   const selectedTheme = themes[themeType];
-    
-  return <ThemeProvider theme={selectedTheme}>{children}</ThemeProvider>;
-};
 
-export default AppTheme;
+  return <ThemeProvider theme={selectedTheme}>{children}</ThemeProvider>;
+}
+
+AppTheme.propTypes = {
+  children: PropTypes.array
+};

--- a/App/theme/AppTheme.js
+++ b/App/theme/AppTheme.js
@@ -14,5 +14,5 @@ export default function AppTheme({ children }) {
 }
 
 AppTheme.propTypes = {
-  children: PropTypes.object
+  children: PropTypes.object.isRequired
 };

--- a/App/theme/AppTheme.js
+++ b/App/theme/AppTheme.js
@@ -14,5 +14,5 @@ export default function AppTheme({ children }) {
 }
 
 AppTheme.propTypes = {
-  children: PropTypes.object.isRequired
+  children: PropTypes.element.isRequired
 };

--- a/App/theme/AppTheme.js
+++ b/App/theme/AppTheme.js
@@ -14,5 +14,5 @@ export default function AppTheme({ children }) {
 }
 
 AppTheme.propTypes = {
-  children: PropTypes.array
+  children: PropTypes.object
 };

--- a/App/theme/AppTheme.js
+++ b/App/theme/AppTheme.js
@@ -1,15 +1,15 @@
-import React from "react";
-import { useSelector } from "react-redux";
-import { ThemeProvider } from "emotion-theming";
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { ThemeProvider } from 'emotion-theming';
 
-import themes from "theme/themes";
-import { selectors } from "store";
+import themes from 'theme/themes';
+import { selectors } from 'store';
 
 const AppTheme = ({ children }) => {
-    const themeType = useSelector(selectors.theme);
-    const selectedTheme = themes[themeType];
+  const themeType = useSelector(selectors.theme);
+  const selectedTheme = themes[themeType];
     
-    return <ThemeProvider theme={selectedTheme}>{children}</ThemeProvider>;
+  return <ThemeProvider theme={selectedTheme}>{children}</ThemeProvider>;
 };
 
 export default AppTheme;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "eject": "expo eject",
     "ios": "expo start --ios",
     "start": "expo start",
-    "test": "jest",
+    "test": "eslint . && jest",
     "test:watch": "jest --watchAll",
     "web": "expo start --web"
   },

--- a/scripts/BibleTextToJson.js
+++ b/scripts/BibleTextToJson.js
@@ -1,8 +1,8 @@
-/*/////////////////////////////////////////// Description /////////////////////////////////////////////
+/*///////////////////////////////////////// Description ////////////////////////////////////////////
 
   Creates a bible .json file from a .txt file
 
-//////////////////////////////////////////////// Usage ////////////////////////////////////////////////
+////////////////////////////////////////////// Usage ///////////////////////////////////////////////
 
   node BibleTextToJson.js [importFileName] [exportFileName]
 
@@ -12,11 +12,12 @@
   example 2 (with args):
     node BibleTextToJson.js Chinese_Bible_Simplified.txt simplified.json
 
-///////////////////////////////////////////// Input/Output /////////////////////////////////////////////
+/////////////////////////////////////////// Input/Output ///////////////////////////////////////////
 
   The expected formats are as follows:
 
-  The import .txt file should contain at least 31,102 seperate lines - 1 line per each verse in the bible.
+  The import .txt file should contain at least 31,102 seperate lines - 1 line per each verse in the
+  bible.
     Each line should be in the format: book chapter:verse text, for example: Joh 11:35 Jesus wept.
     The book name may be abbreviated, but all lines must be in the correct order.
     Leading line whitespace will be ignored.
@@ -44,7 +45,6 @@ const exportFile = args[1] || 'bible.json';
 const content = readFileSync(__dirname + '/' + importFile).toString();
 
 const oldTestLength = 39;
-const newTestLength = 27;
 
 const OLD_TESTAMENT = 'Old Testament';
 const NEW_TESTAMENT = 'New Testament';
@@ -57,7 +57,7 @@ const json = {
 let currentBookIndex = -1;
 let currentTestament = OLD_TESTAMENT;
 
-function isInOldTestament(){
+function isInOldTestament() {
   return currentBookIndex < oldTestLength;
 }
 
@@ -69,11 +69,11 @@ function testamentBookIndex() {
 
 let prevBook = null;
 
-content.split('\n').forEach((line, i) => {
+content.split('\n').forEach(line => {
   const matches = line.match(/^\s*(\w+)\s(\d+):(\d+)\s(.*)$/);
-  
+
   if (matches) {
-    const [, book, chapter, verse, content] = matches;
+    const [, book, chapter, content] = matches;
 
     if (book !== prevBook) {
       currentBookIndex += 1;
@@ -82,12 +82,11 @@ content.split('\n').forEach((line, i) => {
     }
     const bookIndex = testamentBookIndex();
     const chapterIndex = +chapter - 1;
-    const verseIndex = +verse - 1;
 
     if (json[currentTestament].length <= bookIndex) {
       json[currentTestament].push([]);
     }
-      
+
     if (json[currentTestament][bookIndex].length <= chapterIndex) {
       json[currentTestament][bookIndex].push([]);
     }

--- a/scripts/BibleTextToJson.js
+++ b/scripts/BibleTextToJson.js
@@ -46,8 +46,8 @@ const content = readFileSync(__dirname + '/' + importFile).toString();
 const oldTestLength = 39;
 const newTestLength = 27;
 
-const OLD_TESTAMENT = "Old Testament";
-const NEW_TESTAMENT = "New Testament";
+const OLD_TESTAMENT = 'Old Testament';
+const NEW_TESTAMENT = 'New Testament';
 
 const json = {
   [OLD_TESTAMENT]: [],
@@ -95,9 +95,9 @@ content.split('\n').forEach((line, i) => {
     json[currentTestament][bookIndex][chapterIndex].push(content);
 
   }
-})
+});
 
-writeFileSync(__dirname + '/' + exportFile, JSON.stringify(json, null, 2))
+writeFileSync(__dirname + '/' + exportFile, JSON.stringify(json, null, 2));
 
 // END //////////////////////////////////////////////////////////////////////
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,29 +47,7 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.8.6":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.1.tgz#2c55b604e73a40dc21b0e52650b11c65cf276643"
-  integrity sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.0"
-    "@babel/helper-module-transforms" "^7.11.0"
-    "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.1"
-    "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.11.0"
-    "@babel/types" "^7.11.0"
-    convert-source-map "^1.7.0"
-    debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
-    json5 "^2.1.2"
-    lodash "^4.17.19"
-    resolve "^1.3.2"
-    semver "^5.4.1"
-    source-map "^0.5.0"
-
-"@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.7.5", "@babel/core@^7.8.6":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.5.tgz#6ad96e2f71899ea3f9b651f0a911e85205d1ff6d"
   integrity sha512-fsEANVOcZHzrsV6dMVWqpSeXClq3lNbYrfFGme6DE25FQWe7pyeYpXyx9guqUnpy466JLzZ8z4uwSr2iv60V5Q==
@@ -91,7 +69,7 @@
     semver "^5.4.1"
     source-map "^0.6.1"
 
-"@babel/generator@^7.11.0", "@babel/generator@^7.11.5", "@babel/generator@^7.5.0", "@babel/generator@^7.9.0":
+"@babel/generator@^7.11.5", "@babel/generator@^7.5.0", "@babel/generator@^7.9.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.5.tgz#a5582773425a468e4ba269d9a1f701fbca6a7a82"
   integrity sha512-9UqHWJ4IwRTy4l0o8gq2ef8ws8UPzvtMkVKjTLAiRmza9p9V6Z+OfuNd9fB1j5Q67F+dVJtPC2sZXI8NM9br4g==
@@ -324,12 +302,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.11.1":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.2.tgz#0882ab8a455df3065ea2dcb4c753b2460a24bead"
-  integrity sha512-Vuj/+7vLo6l1Vi7uuO+1ngCDNeVmNbTngcJFKCR/oEtz8tKz0CJxZEGmPt9KcIloZhOZ3Zit6xbpXT2MDlS9Vw==
-
-"@babel/parser@^7.1.0", "@babel/parser@^7.11.5", "@babel/parser@^7.9.0":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.9.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
@@ -1035,22 +1008,7 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/traverse@^7.0.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.0.tgz#9b996ce1b98f53f7c3e4175115605d56ed07dd24"
-  integrity sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
-  dependencies:
-    "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.0"
-    "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.11.0"
-    "@babel/types" "^7.11.0"
-    debug "^4.1.0"
-    globals "^11.1.0"
-    lodash "^4.17.19"
-
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.11.5", "@babel/traverse@^7.9.0":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.11.5", "@babel/traverse@^7.9.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
   integrity sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==
@@ -1065,16 +1023,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.4.4":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
-  integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.10.4"
-    lodash "^4.17.19"
-    to-fast-properties "^2.0.0"
-
-"@babel/types@^7.11.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.9.0":
+"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.3.0", "@babel/types@^7.3.3", "@babel/types@^7.4.4", "@babel/types@^7.9.0":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
@@ -1194,14 +1143,20 @@
   resolved "https://registry.yarnpkg.com/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz#8eed982e2ee6f7f4e44c253e12962980791efd46"
   integrity sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==
 
-"@eslint/eslintrc@^0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.0.tgz#3d1f19fb797d42fb1c85458c1c73541eeb1d9e76"
-  integrity sha512-bfL5365QSCmH6cPeFT7Ywclj8C7LiF7sO6mUGzZhtAMV7iID1Euq6740u/SRi4C80NOnVz/CEfK8/HO+nCAPJg==
+"@eslint/eslintrc@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
+  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
+    espree "^7.3.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
     import-fresh "^3.2.1"
+    js-yaml "^3.13.1"
+    lodash "^4.17.19"
+    minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
 "@expo/babel-preset-cli@0.2.17":
@@ -1257,14 +1212,14 @@
     mv "~2"
     safe-json-stringify "~1"
 
-"@expo/config@3.2.21":
-  version "3.2.21"
-  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.2.21.tgz#786e998245a212b76235c3be82560060af832834"
-  integrity sha512-Q+RB4lIx8f/39o5suB/O41dKgKGgEQSb0thsIaKGXC1LE7Z5zQtxtSbDAUGsWCKNSOV0KacsCdo7ovLMtYCLJw==
+"@expo/config@3.2.22":
+  version "3.2.22"
+  resolved "https://registry.yarnpkg.com/@expo/config/-/config-3.2.22.tgz#b9573fa6bee224592b83de9b82f47b2e9f705257"
+  integrity sha512-ZcSHuhwC5OXQZF24ls8rxkQE3a9G6dKe7IiTQxOzxVJ3wkF5ESoukaZoA9cg8CDfReIPq9NCMq2mEgTjbNoDRg==
   dependencies:
     "@babel/register" "^7.8.3"
     "@expo/babel-preset-cli" "0.2.17"
-    "@expo/image-utils" "0.3.3"
+    "@expo/image-utils" "0.3.4"
     "@expo/json-file" "8.2.22"
     "@expo/plist" "0.0.9"
     fs-extra "9.0.0"
@@ -1292,24 +1247,24 @@
     xcode "^3.0.0"
     xml-js "^1.6.11"
 
-"@expo/dev-server@0.1.23":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.23.tgz#5a5dc9b108e4c085dbbda34dfcfa838c4a31137f"
-  integrity sha512-a0nFohvjyabimy6LcpIdTQDKIRakk1733iKasgiiCyuJ2l2ZUBZUCkgWiynFJzrlSI2lTvaUAIJKo0xckWKm+Q==
+"@expo/dev-server@0.1.24":
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@expo/dev-server/-/dev-server-0.1.24.tgz#dc5edc9f8089a65cdc0858e6efa505f1a2140a0c"
+  integrity sha512-/XKPrDC6yJ9zBrtOyBGsV0pFNR86pQiOgVC6av2E/B53m0t+TOGXarW0yGagaGAFU5mNfwZmtahQi+9Yz0ZlFQ==
   dependencies:
     "@expo/bunyan" "3.0.2"
-    "@expo/config" "3.2.21"
-    "@expo/metro-config" "0.1.23"
+    "@expo/config" "3.2.22"
+    "@expo/metro-config" "0.1.24"
     "@react-native-community/cli-server-api" "4.9.0"
     body-parser "1.19.0"
     serialize-error "6.0.0"
 
-"@expo/dev-tools@0.13.36":
-  version "0.13.36"
-  resolved "https://registry.yarnpkg.com/@expo/dev-tools/-/dev-tools-0.13.36.tgz#4090028d372056f0c6d4599a08d0656c4fa20c7c"
-  integrity sha512-QELl7ZR9PpofNmPimjR671QLjBGO4E6yI4J0HigJRtcrx0l75dqW7JAEg8BsyWeoX5aF7Hl+nED2WB10PXsvoA==
+"@expo/dev-tools@0.13.37":
+  version "0.13.37"
+  resolved "https://registry.yarnpkg.com/@expo/dev-tools/-/dev-tools-0.13.37.tgz#e0f7333973ce76559ddde1d4e7b3143e908775f5"
+  integrity sha512-wxpRh/WheLXLQ4gKrmm2NQ3AUIoW0EcvjxpYfzBGz8m04qpJKgGsYidTBkGL07N/PyflgccGVwR7h4yFuJ4zpg==
   dependencies:
-    "@expo/config" "3.2.21"
+    "@expo/config" "3.2.22"
     base64url "3.0.1"
     express "4.16.4"
     freeport-async "2.0.0"
@@ -1335,10 +1290,10 @@
     "@expo/logger" "0.0.13"
     "@expo/turtle-spawn" "0.0.13"
 
-"@expo/image-utils@0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.3.tgz#c7f3377d534d9aad470d16997e73d3cdedd0f30d"
-  integrity sha512-XSPbUYMUmBVfEMoY+JVJVtiCi3/oQl3NMVpoDWPW/HVa2jqK4pz9xjks4F8QcMep1/DsisclLWDeuFOMzJqwLw==
+"@expo/image-utils@0.3.4":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.3.4.tgz#ff042ff33dfb107f4bfa3421c2e6c9ecdc46aa64"
+  integrity sha512-ifW7ozVv74GTydPHuUapYU2Gb5oVDJLOwEY1hwcVQVkSs2dT2PBMGw8lFtX1XinFDSVQ5xA4yiyJDP+ycYaC4Q==
   dependencies:
     "@expo/spawn-async" "1.5.0"
     chalk "^4.0.0"
@@ -1370,12 +1325,12 @@
   dependencies:
     "@expo/bunyan" "^3.0.4"
 
-"@expo/metro-config@0.1.23":
-  version "0.1.23"
-  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.23.tgz#178a697272252ff95ab88cc3a780d8c81d70c0aa"
-  integrity sha512-vMLsnFXdK97zQdKjsifV0QcCcrHvKOj3/ihsS0FKKw3WV9ab/Z0nc2LEId41CSqAoPgLB2kPn66xRe1sZUpbkA==
+"@expo/metro-config@0.1.24":
+  version "0.1.24"
+  resolved "https://registry.yarnpkg.com/@expo/metro-config/-/metro-config-0.1.24.tgz#ef68931929c3f88ebe6e36b31645cdc242317753"
+  integrity sha512-T0xBuHEl6DudK+cza19K01kIgvWNYNLQ78k31EQp4ZlSkeAj1SrWKi6SMBnDl4ewm9RPY3al1iclro6ZhPMFyw==
   dependencies:
-    "@expo/config" "3.2.21"
+    "@expo/config" "3.2.22"
     metro-react-native-babel-transformer "^0.58.0"
 
 "@expo/ngrok-bin-darwin-ia32@2.2.8":
@@ -1556,21 +1511,21 @@
   dependencies:
     lodash "^4.17.4"
 
-"@expo/webpack-config@0.12.27":
-  version "0.12.27"
-  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.27.tgz#fbfa8ee43318cee3b35592d60190a610bdf4861d"
-  integrity sha512-KBu8ycbpRWzcuK9OXPnAF/mC771inLOcFPZNFkCX2CIgXhg1jJOfADcJsCAxwTJ5RFIXdBHS4sDMi7c8E+D+KA==
+"@expo/webpack-config@0.12.28":
+  version "0.12.28"
+  resolved "https://registry.yarnpkg.com/@expo/webpack-config/-/webpack-config-0.12.28.tgz#8536b7c1a4a87dafd9eb3c2f86b782d23071beb1"
+  integrity sha512-PVl4iCSxcIxNv6S7Guq4OIOeOUMNnOUPaY9yD/AjiybRhzyP4x79E7Q5WZGzvVtWmjbZWmKLTHKqhxQVfu7Axw==
   dependencies:
     "@babel/core" "7.9.0"
     "@babel/runtime" "7.9.0"
-    "@expo/config" "3.2.21"
+    "@expo/config" "3.2.22"
     "@pmmmwh/react-refresh-webpack-plugin" "^0.3.3"
     babel-loader "8.1.0"
     chalk "^4.0.0"
     clean-webpack-plugin "^3.0.0"
     copy-webpack-plugin "~6.0.3"
     css-loader "~3.6.0"
-    expo-pwa "0.0.33"
+    expo-pwa "0.0.34"
     file-loader "~6.0.0"
     find-yarn-workspace-root "~2.0.0"
     getenv "^0.7.0"
@@ -1605,14 +1560,14 @@
     pouchdb-collections "^1.0.1"
     tiny-queue "^0.2.1"
 
-"@expo/xdl@57.9.33":
-  version "57.9.33"
-  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-57.9.33.tgz#0f195a1eb85273b1437e7cea0a00caaad6d1929c"
-  integrity sha512-Ra1LhGMfGSee/tZO3/YPnTXKgxlxMfzCD4JE2/DSlF7HnOMfRDmB4joanqmbHRP22/tPp2l438OJt3CF5b31CQ==
+"@expo/xdl@57.9.34":
+  version "57.9.34"
+  resolved "https://registry.yarnpkg.com/@expo/xdl/-/xdl-57.9.34.tgz#decbe74c7bd8ea0247ec507ccf67ce6adff3dbe2"
+  integrity sha512-N94OhJDu2Htzpxz+FPO65oFvDsq/pL9Eipfd36tes+rtCYNtq6NdFnkdhJaNxsbpXlgbe2J7akZYyqp1D8kgpg==
   dependencies:
     "@expo/bunyan" "3.0.2"
-    "@expo/config" "3.2.21"
-    "@expo/dev-server" "0.1.23"
+    "@expo/config" "3.2.22"
+    "@expo/dev-server" "0.1.24"
     "@expo/json-file" "8.2.22"
     "@expo/ngrok" "2.4.3"
     "@expo/osascript" "2.0.23"
@@ -1620,8 +1575,9 @@
     "@expo/plist" "0.0.9"
     "@expo/schemer" "1.3.20"
     "@expo/spawn-async" "1.5.0"
-    "@expo/webpack-config" "0.12.27"
+    "@expo/webpack-config" "0.12.28"
     "@hapi/joi" "^17.1.1"
+    "@types/text-table" "^0.2.1"
     analytics-node "3.3.0"
     axios "0.19.0"
     boxen "4.1.0"
@@ -1660,6 +1616,7 @@
     package-json "6.4.0"
     pacote "11.1.0"
     pascal-case "2.0.1"
+    pretty-bytes "^5.3.0"
     probe-image-size "4.0.0"
     progress "2.0.3"
     raven "2.6.3"
@@ -1672,7 +1629,10 @@
     slugify "^1.3.6"
     source-map-support "0.4.18"
     split "1.0.1"
+    strip-ansi "^6.0.0"
     tar "4.4.6"
+    terminal-link "^2.1.1"
+    text-table "^0.2.0"
     tree-kill "1.2.2"
     url-join "4.0.0"
     uuid "3.3.2"
@@ -2355,9 +2315,9 @@
   integrity sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==
 
 "@npmcli/git@^2.0.1":
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/@npmcli/git/-/git-2.0.3.tgz#41a13cc698d257c7e38a287e233dafe7354dd4ab"
-  integrity sha512-c/ODsV5ppjB12VDXKc6hzVNgg6ZJX/etILUn3WgF5NLAYBhQLJ3fBq6uB2jQD4OwqOzJdPT1/xA3Xh3aaWGk5w==
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/@npmcli/git/-/git-2.0.4.tgz#725f5e32864f3849420e84baf130e426a707cbb7"
+  integrity sha512-OJZCmJ9DNn1cz9HPXXsPmUBnqaArot3CGYo63CyajHQk+g87rPXVOJByGsskQJhPsUUEXJcsZ2Q6bWd2jSwnBA==
   dependencies:
     "@npmcli/promise-spawn" "^1.1.0"
     lru-cache "^6.0.0"
@@ -2905,6 +2865,11 @@
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
 
+"@types/text-table@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@types/text-table/-/text-table-0.2.1.tgz#39c4d4a058a82f677392dfd09976e83d9b4c9264"
+  integrity sha512-dchbFCWfVgUSWEvhOkXGS7zjm+K7jCUvGrQkAHPk2Fmslfofp4HQTH2pqnQ3Pw5GPYv0zWa2AQjKtsfZThuemQ==
+
 "@types/tmp@^0.0.33":
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
@@ -3447,6 +3412,11 @@ aproba@^1.0.3, aproba@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+
+arch@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/arch/-/arch-2.1.2.tgz#0c52bbe7344bb4fa260c443d2cbad9c00ff2f0bf"
+  integrity sha512-NTBIIbAfkJeIletyABbVtdPgeKfDafR+1mZV/AyyfC1UkVkp9iUjV+wwmqtUgphHYajbI86jejBJp5e+jkGTiQ==
 
 are-we-there-yet@~1.1.2:
   version "1.1.5"
@@ -4021,14 +3991,6 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-bl@^1.0.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-1.2.2.tgz#a160911717103c07410cef63ef51b397c025af9c"
-  integrity sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==
-  dependencies:
-    readable-stream "^2.3.5"
-    safe-buffer "^5.1.1"
-
 bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -4265,7 +4227,7 @@ buffer-alloc-unsafe@^1.1.0:
   resolved "https://registry.yarnpkg.com/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz#bd7dc26ae2972d0eda253be061dba992349c19f0"
   integrity sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==
 
-buffer-alloc@^1.1.0, buffer-alloc@^1.2.0:
+buffer-alloc@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/buffer-alloc/-/buffer-alloc-1.2.0.tgz#890dd90d923a873e08e10e5fd51a57e5b7cce0ec"
   integrity sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==
@@ -4720,6 +4682,15 @@ cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
+
+clipboardy@2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/clipboardy/-/clipboardy-2.3.0.tgz#3c2903650c68e46a91b388985bc2774287dba290"
+  integrity sha512-mKhiIL2DrQIsuXMgBgnfEHOZOryC7kY7YO//TN6c63wlEm3NG5tz+YgY5rVi29KCmq/QQjKYvM7a19+MDOTHOQ==
+  dependencies:
+    arch "^2.1.1"
+    execa "^1.0.0"
+    is-wsl "^2.1.1"
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -5971,9 +5942,9 @@ ee-first@1.1.1:
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
 electron-to-chromium@^1.3.378, electron-to-chromium@^1.3.523:
-  version "1.3.556"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.556.tgz#d2a8fed6b93051c5c27d182c43c7bc4d88b77afb"
-  integrity sha512-g5cGpg6rOCXxyfaLCQIWz9Fx+raFfbZ6sc4QLfvvaiCERBzY6YD6rh5d12QN++bEF1Tm9osYnxP37lbN/92j4A==
+  version "1.3.557"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.557.tgz#00cafeed4397a6a9d1036911e434bc7404dc5e7c"
+  integrity sha512-M2p3nWulBqSEIisykYUVYnaSuRikHvxv8Wf209/Vg/sjrOew12hBQv2JvNGy+i+eDeJU9uQ3dbUbCCQ/CkudEg==
 
 elliptic@^6.5.3:
   version "6.5.3"
@@ -6283,12 +6254,12 @@ eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint@^7.8.0:
-  version "7.8.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.8.0.tgz#9a3e2e6e4d0a3f8c42686073c25ebf2e91443e8a"
-  integrity sha512-qgtVyLZqKd2ZXWnLQA4NtVbOyH56zivOAdBFWE54RFkSZjokzNrcP4Z0eVWsZ+84ByXv+jL9k/wE1ENYe8xRFw==
+  version "7.8.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.8.1.tgz#e59de3573fb6a5be8ff526c791571646d124a8fa"
+  integrity sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.1.0"
+    "@eslint/eslintrc" "^0.1.3"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -6503,28 +6474,28 @@ expo-asset@~8.1.7:
     url-parse "^1.4.4"
 
 expo-cli@^3.25.1:
-  version "3.25.1"
-  resolved "https://registry.yarnpkg.com/expo-cli/-/expo-cli-3.25.1.tgz#42e91e07c817fad322f4946917cde31e3df07bee"
-  integrity sha512-yonU+1XIlvp296BEoQBLckyZmNaeonRXkdlq8xyShx/vGM7Ql62P9BevF2mf5JKDE42dR4sf+jcYplf4sNZi/Q==
+  version "3.26.0"
+  resolved "https://registry.yarnpkg.com/expo-cli/-/expo-cli-3.26.0.tgz#b94f1fa56a41a1eedfb35368f3269931e5506246"
+  integrity sha512-qQG4523npV9rED+mHOxMlEmoPZyQR/uGD5pXNuXMMHEgSaSOtWAxAdcZEoRtYTq+k41Z85Lfh90J1oM7nHUbvQ==
   dependencies:
     "@expo/build-tools" "^0.1.15"
     "@expo/bunyan" "3.0.2"
-    "@expo/config" "3.2.21"
-    "@expo/dev-tools" "0.13.36"
+    "@expo/config" "3.2.22"
+    "@expo/dev-tools" "0.13.37"
     "@expo/json-file" "8.2.22"
     "@expo/package-manager" "0.0.31"
     "@expo/plist" "0.0.9"
     "@expo/results" "^1.0.0"
     "@expo/simple-spinner" "1.0.2"
     "@expo/spawn-async" "1.5.0"
-    "@expo/xdl" "57.9.33"
+    "@expo/xdl" "57.9.34"
     "@hapi/joi" "^17.1.1"
-    axios "0.19.0"
     babel-runtime "6.26.0"
     base32.js "0.1.0"
     boxen "4.1.0"
     chalk "^4.0.0"
     cli-table3 "^0.6.0"
+    clipboardy "2.3.0"
     command-exists "^1.2.8"
     commander "2.17.1"
     concat-stream "1.6.2"
@@ -6541,6 +6512,7 @@ expo-cli@^3.25.1:
     indent-string "4.0.0"
     inquirer "5.2.0"
     invariant "2.2.4"
+    keychain "1.3.0"
     klaw-sync "6.0.0"
     leven "^3.1.0"
     lodash "4.17.15"
@@ -6555,7 +6527,8 @@ expo-cli@^3.25.1:
     react-dev-utils "~10.2.1"
     semver "5.5.0"
     slash "1.0.0"
-    targz "^1.0.1"
+    strip-ansi "^6.0.0"
+    tar "^6.0.5"
     tempy "^0.3.0"
     terminal-link "^2.1.1"
     untildify "3.0.3"
@@ -6636,13 +6609,13 @@ expo-permissions@~9.0.1:
   resolved "https://registry.yarnpkg.com/expo-permissions/-/expo-permissions-9.0.1.tgz#dc10b58654bbe39bbbed5827369942b01b08055e"
   integrity sha512-CosJgy8XQRN/OFG2JTQDcFxz3XTGi27coCMym/hVXWtQfk0z6PwdRG5IXHfLGuSckwIcgmirrwm2+Zc0X3MmNg==
 
-expo-pwa@0.0.33:
-  version "0.0.33"
-  resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.33.tgz#721cc6db97da55470417e2abf0c651cfd8253347"
-  integrity sha512-0/PNbgYi6O59IRAIrRlcmOpHtlz/mfWlxPiv8KLSIjOvmJrYi8dQ+upsgCDIrvNGcxZuW4K2n6Bf6mCosC0s+g==
+expo-pwa@0.0.34:
+  version "0.0.34"
+  resolved "https://registry.yarnpkg.com/expo-pwa/-/expo-pwa-0.0.34.tgz#f7909f857a75aaf6d9a2bb1f5559b93e070c50aa"
+  integrity sha512-7ijS0W8Xq9n3cCS6WOwVGWo6iHsj3E8ABHYDxz7TwecCdVe3gkSF/6wG+VACU2MWC+y3Ifa8zDyZT6VgzS3a0g==
   dependencies:
-    "@expo/config" "3.2.21"
-    "@expo/image-utils" "0.3.3"
+    "@expo/config" "3.2.22"
+    "@expo/image-utils" "0.3.4"
     "@expo/json-file" "8.2.22"
     chalk "^4.0.0"
     commander "2.20.0"
@@ -7261,11 +7234,6 @@ from2@^2.1.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
-
-fs-constants@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
-  integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
 fs-extra@9.0.0:
   version "9.0.0"
@@ -9514,6 +9482,11 @@ jsx-ast-utils@^2.4.1:
     array-includes "^3.1.1"
     object.assign "^4.1.0"
 
+keychain@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/keychain/-/keychain-1.3.0.tgz#ccb8ddc64a62f34d541ac25e612186442a432410"
+  integrity sha1-zLjdxkpi801UGsJeYSGGRCpDJBA=
+
 keyv@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.1.0.tgz#ecc228486f69991e49e9476485a5be1e8fc5c4d9"
@@ -10697,9 +10670,9 @@ node-forge@0.9.0:
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
 
 node-forge@^0.9.1:
-  version "0.9.1"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
-  integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.2.tgz#b35a44c28889b2ea55cabf8c79e3563f9676190a"
+  integrity sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==
 
 node-gyp@^6.1.0:
   version "6.1.0"
@@ -12149,6 +12122,11 @@ pretty-bytes@^4.0.2:
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
   integrity sha1-sr+C5zUNZcbDOqlaqlpPYyf2HNk=
 
+pretty-bytes@^5.3.0:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.4.1.tgz#cd89f79bbcef21e3d21eb0da68ffe93f803e884b"
+  integrity sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==
+
 pretty-error@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -12315,14 +12293,6 @@ public-encrypt@^4.0.0:
     parse-asn1 "^5.0.0"
     randombytes "^2.0.1"
     safe-buffer "^5.1.2"
-
-pump@^1.0.0:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/pump/-/pump-1.0.3.tgz#5dfe8311c33bbf6fc18261f9f34702c47c08a954"
-  integrity sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==
-  dependencies:
-    end-of-stream "^1.1.0"
-    once "^1.3.1"
 
 pump@^2.0.0:
   version "2.0.1"
@@ -12744,7 +12714,7 @@ read-pkg@^5.2.0:
     parse-json "^5.0.0"
     type-fest "^0.6.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.0, readable-stream@^2.3.3, readable-stream@^2.3.5, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -14251,29 +14221,6 @@ tapable@^1.0.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tar-fs@^1.8.1:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-1.16.3.tgz#966a628841da2c4010406a82167cbd5e0c72d509"
-  integrity sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==
-  dependencies:
-    chownr "^1.0.1"
-    mkdirp "^0.5.1"
-    pump "^1.0.0"
-    tar-stream "^1.1.2"
-
-tar-stream@^1.1.2:
-  version "1.6.2"
-  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
-  integrity sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==
-  dependencies:
-    bl "^1.0.0"
-    buffer-alloc "^1.2.0"
-    end-of-stream "^1.0.0"
-    fs-constants "^1.0.0"
-    readable-stream "^2.3.0"
-    to-buffer "^1.1.1"
-    xtend "^4.0.0"
-
 tar@4.4.6:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/tar/-/tar-4.4.6.tgz#63110f09c00b4e60ac8bcfe1bf3c8660235fbc9b"
@@ -14300,7 +14247,7 @@ tar@^4.4.12:
     safe-buffer "^5.1.2"
     yallist "^3.0.3"
 
-tar@^6.0.1, tar@^6.0.2:
+tar@^6.0.1, tar@^6.0.2, tar@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/tar/-/tar-6.0.5.tgz#bde815086e10b39f1dcd298e89d596e1535e200f"
   integrity sha512-0b4HOimQHj9nXNEAA7zWwMM91Zhhba3pspja6sQbgTpynOJf+bkjBnfybNYzbpLbnwXnbyB4LOREvlyXLkCHSg==
@@ -14311,13 +14258,6 @@ tar@^6.0.1, tar@^6.0.2:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
-
-targz@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/targz/-/targz-1.0.1.tgz#8f76a523694cdedfbb5d60a4076ff6eeecc5398f"
-  integrity sha1-j3alI2lM3t+7XWCkB2/27uzFOY8=
-  dependencies:
-    tar-fs "^1.8.1"
 
 temp-dir@^1.0.0:
   version "1.0.0"
@@ -14502,11 +14442,6 @@ to-arraybuffer@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz#7d229b1fcc637e466ca081180836a7aabff83f43"
   integrity sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=
-
-to-buffer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/to-buffer/-/to-buffer-1.1.1.tgz#493bd48f62d7c43fcded313a03dcadb2e1213a80"
-  integrity sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==
 
 to-fast-properties@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Implements basic PropTypes on all components. Also fixes some ESLint issues, ESLint is now 100% happy! :100: Definitely make suggestions if you see anything you think needs to be adjusted/tweaked/changed in any of the configs.

NOTE: I was originally going to do PropTypes using validator functions like so:
```js
MyComponent.propTypes = {
  numbers: PropTypes.arrayOf(PropTypes.number)
};
```
But it turns out after React 16, this has been discontinued: https://www.npmjs.com/package/prop-types#difference-from-reactproptypes--dont-call-validator-functions

This is news to me, so I'll have to understand this a bit better. For now, the PropTypes are just using the basic types (e.g. `PropTypes.array`, `PropTypes.string`, etc...).