### PR TITLE
Italics

### DIFF
--- a/App/RootContainer.js
+++ b/App/RootContainer.js
@@ -5,6 +5,7 @@ The purpose of this component is to place any app level logic that needs to happ
 */
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import { View } from 'react-native';
 import { useSelector, useDispatch } from 'react-redux';
 
@@ -30,3 +31,7 @@ export default function RootContainer({ children }) {
     </View>
   );
 }
+
+RootContainer.propTypes = {
+  children: PropTypes.node,
+};

--- a/App/components/Bible/Verse.js
+++ b/App/components/Bible/Verse.js
@@ -20,11 +20,8 @@ export default function Verse({ number, text }) {
 
   const isMounted = useIsMounted();
 
-  const breakVerseIntoParts = () => text.split(/\[|\]/);
-
-  const doesItStartWithItalics = () => text.startsWith('[');
-
-  const isItalicized = (i) => i % 2 === (startsWithItalics ? 0 : 1);
+  const [verseParts, setVerseParts] = useState(breakVerseIntoParts());
+  const [startsWithItalics, setStartsWithItalics] = useState(doesItStartWithItalics());
 
   useEffect(() => {
     if (!isMounted) return;
@@ -32,11 +29,17 @@ export default function Verse({ number, text }) {
     setStartsWithItalics(doesItStartWithItalics());
   }, [isEnglish, text, size]);
 
-  const [verseParts, setVerseParts] = useState(breakVerseIntoParts());
-  const [startsWithItalics, setStartsWithItalics] = useState(
-    doesItStartWithItalics()
-  );
+  function breakVerseIntoParts() {
+    return text.split(/\[|\]/);
+  }
 
+  function doesItStartWithItalics() {
+    return text.startsWith('[');
+  }
+
+  function isItalicized(i) {
+    return i % 2 === (startsWithItalics ? 0 : 1);
+  }
   return (
     <VerseContainer size={size}>
       <Text size={size}>

--- a/App/components/Bible/Verse.js
+++ b/App/components/Bible/Verse.js
@@ -1,24 +1,80 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
 import styled from '@emotion/native';
 import { useSelector } from 'react-redux';
-import PropTypes from 'prop-types';
 import { selectors } from 'store';
+import { useIsMounted } from 'lib/hooks';
 
 export default function Verse({ number, text }) {
-  // TODO: Account for italics in english
-  const fontSize = useSelector(selectors.fontSize);
+  const size = useSelector(selectors.fontSize);
+  const isEnglish = useSelector(selectors.language) === 'english';
+
+  if (!isEnglish)
+    return (
+      <VerseContainer size={size}>
+        <Text size={size}>
+          {number} {text}
+        </Text>
+      </VerseContainer>
+    );
+
+  const isMounted = useIsMounted();
+
+  const breakVerseIntoParts = () => text.split(/\[|\]/);
+
+  const doesItStartWithItalics = () => text.startsWith('[');
+
+  const isItalicized = (i) => i % 2 === (startsWithItalics ? 0 : 1);
+
+  useEffect(() => {
+    if (!isMounted) return;
+    setVerseParts(breakVerseIntoParts());
+    setStartsWithItalics(doesItStartWithItalics());
+  }, [isEnglish, text, size]);
+
+  const [verseParts, setVerseParts] = useState(breakVerseIntoParts());
+  const [startsWithItalics, setStartsWithItalics] = useState(
+    doesItStartWithItalics()
+  );
+
   return (
-    <Text fontSize={fontSize}>
-      {number} {text}
-    </Text>
+    <VerseContainer size={size}>
+      <Text size={size}>
+        {`${number} `}
+        {verseParts.map((phrase, i) => {
+          return (
+            <Text key={phrase + i} size={size} italicized={isItalicized(i)}>
+              {phrase}
+            </Text>
+          );
+        })}
+      </Text>
+    </VerseContainer>
   );
 }
 
-const Text = styled.Text(({ theme, fontSize }) => ({
-  fontSize: theme.fontSize[fontSize],
-  lineHeight: 27,
-  marginBottom: 13,
+const lineHeightMap = {
+  small: 21,
+  medium: 27,
+  large: 32,
+};
+
+const marginBottomMap = {
+  small: 13,
+  medium: 17,
+  large: 21,
+};
+
+const VerseContainer = styled.View(({ size }) => ({
+  marginBottom: marginBottomMap[size],
+}));
+
+const Text = styled.Text(({ theme, size, italicized }) => ({
+  fontSize: theme.fontSize[size],
+  lineHeight: lineHeightMap[size],
   color: theme.text.reading,
+  fontStyle: italicized ? 'italic' : 'normal',
+  fontWeight: italicized ? '300' : '400',
 }));
 
 Verse.propTypes = {

--- a/App/components/Bible/Verse.test.js
+++ b/App/components/Bible/Verse.test.js
@@ -6,18 +6,26 @@ import themes from 'theme/themes';
 import Verse from './Verse';
 import MockStore from 'test/mocks/MockStore';
 
-function setup() {
+function setup({ text }) {
   return render(
     <MockStore>
       <ThemeProvider theme={themes['light']}>
-        <Verse number={1} text="And it came to pass..." />
+        <Verse number={1} text={text} />
       </ThemeProvider>
     </MockStore>
   );
 }
 
 test('renders a verse', () => {
-  const { getByText } = setup();
+  const { getByText } = setup({ text: 'And it came to pass...' });
+  const verse = getByText(/1 and it came to pass/i);
+
+  expect(verse).toBeDefined();
+});
+
+
+test('removes [bracket] from verse and renders in italics', () => {
+  const { getByText } = setup({ text: 'And it [came] to pass...' });
   const verse = getByText(/1 and it came to pass/i);
 
   expect(verse).toBeDefined();

--- a/App/components/Settings/SettingsOption.js
+++ b/App/components/Settings/SettingsOption.js
@@ -23,11 +23,16 @@ export default function SettingsOption({ label, selected, onPress, fontSize }) {
   );
 }
 
+SettingsOption.defaultProps = {
+  onPress: () => {},
+  fontSize: 'medium',
+};
+
 SettingsOption.propTypes = {
   label: PropTypes.string.isRequired,
   selected: PropTypes.bool.isRequired,
-  onPress: PropTypes.func.isRequired,
-  fontSize: PropTypes.string.isRequired,
+  onPress: PropTypes.func,
+  fontSize: PropTypes.string,
 };
 
 const ButtonContainer = styled.View(() => ({
@@ -39,9 +44,16 @@ const Button = styled.TouchableOpacity(() => ({
   marginRight: 20,
 }));
 
+// keeps the text in place with change in size
+const marginMap = {
+  small: 23.5,
+  medium: 20,
+  large: 14,
+};
+
 const Option = styled.Text(({ theme, fontSize }) => ({
-  fontSize: theme.fontSize[fontSize] || 17,
+  fontSize: theme.fontSize[fontSize],
   marginLeft: 20,
-  marginBottom: 20,
+  marginBottom: marginMap[fontSize],
   color: theme.text.menu,
 }));

--- a/App/screens/Drawer.js
+++ b/App/screens/Drawer.js
@@ -88,7 +88,7 @@ export default function Drawer({ navigation }) {
 }
 
 Drawer.propTypes = {
-  navigation: PropTypes.shape({ navigate: PropTypes.object.isRequired }).isRequired
+  navigation: PropTypes.shape({ navigate: PropTypes.func.isRequired }).isRequired
 };
 
 const BookSelected = styled.View(() => ({

--- a/App/store/reducers.js
+++ b/App/store/reducers.js
@@ -4,7 +4,7 @@ export const initialState = {
   storeRehydrated: false,
   theme: 'light',
   language: 'english', // simplified, traditional
-  fontSize: 'medium',
+  fontSize: 'medium', // small, large
   showDropdown: false,
   currentScripture: {
     testament: 'old', // new

--- a/App/theme/themes.js
+++ b/App/theme/themes.js
@@ -1,3 +1,9 @@
+const fontSize = {
+  small: 14,
+  medium: 17,
+  large: 22,
+};
+
 export default {
   light: {
     background: {
@@ -16,11 +22,7 @@ export default {
     border: {
       color: '#757575',
     },
-    fontSize: {
-      small: 14,
-      medium: 17,
-      large: 22,
-    },
+    fontSize,
   },
   dark: {
     background: {
@@ -39,10 +41,6 @@ export default {
     border: {
       color: '#c4c4c4',
     },
-    fontSize: {
-      small: 14,
-      medium: 17,
-      large: 22,
-    },
+    fontSize,
   },
 };

--- a/package.json
+++ b/package.json
@@ -49,7 +49,10 @@
     "react-test-renderer": "^16.13.1"
   },
   "jest": {
-    "preset": "react-native"
+		"preset": "react-native",
+		"setupFiles": [
+      "<rootDir>/test/setup.js"
+    ]
   },
   "pre-commit": [
     "test"

--- a/package.json
+++ b/package.json
@@ -49,8 +49,8 @@
     "react-test-renderer": "^16.13.1"
   },
   "jest": {
-		"preset": "react-native",
-		"setupFiles": [
+    "preset": "react-native",
+    "setupFiles": [
       "<rootDir>/test/setup.js"
     ]
   },

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+jest.mock('@react-native-community/async-storage', () => {
+  return {};
+});


### PR DESCRIPTION
Resolves #11
English KJV translation has [brackets] around words that should be italicized .
This change parses through english verses (not Chinese) and renders the bracketed words in italics.

Also added unit test, and cleaned up a few areas to make linter happy